### PR TITLE
feat(scraper): organizer type authority — Wave 2 code cycle

### DIFF
--- a/scraper/_oneoff_repair_organizer_type_arrays.py
+++ b/scraper/_oneoff_repair_organizer_type_arrays.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""
+Phase A.5 — repair co_organizer / sponsor parallel type-array cardinality.
+
+Finds every event (active + inactive) where
+    COALESCE(cardinality(co_organizers), 0) != COALESCE(cardinality(co_organizer_types), 0)
+  or
+    COALESCE(cardinality(sponsors), 0)     != COALESCE(cardinality(sponsor_types), 0)
+and proposes a cardinality-aligning repair. Default mode is DRY-RUN — it only
+prints a manifest and writes JSON to --out; it does NOT touch the database
+unless --apply is passed.
+
+Scope is table-wide (not active-only) because the Phase B cardinality CHECK is
+a validated table constraint: any inactive-event mismatch would block it too.
+
+Repair contract (cardinality alignment ONLY — no entity-type refinement, no
+LLM, no dependency on any not-yet-seeded registry):
+  - names is NULL           -> type array set to NULL
+  - names is []             -> type array set to []
+  - names non-empty:
+      per index i, keep the existing same-index type if it is one of the
+      canonical 10 values; otherwise fill 'unknown'. Never shift a previous
+      index's type into the next slot.
+  - type array LONGER than names (orphan trailing types) -> flagged for MANUAL
+      review; NOT auto-truncated (an orphan type may signal a dropped name).
+  - if the role's type array is protected by a field_corrections row -> skipped
+      and routed to the manual queue (FC keeps top priority).
+
+Registry-based type refinement is intentionally deferred to Phase D.
+
+Usage:
+    python _oneoff_repair_organizer_type_arrays.py                # dry-run
+    python _oneoff_repair_organizer_type_arrays.py --out .        # manifest to cwd
+    python _oneoff_repair_organizer_type_arrays.py --apply        # (NOT this batch)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+from collections import Counter
+from datetime import datetime, timezone
+from typing import Any
+
+from dotenv import load_dotenv
+
+load_dotenv(os.path.join(os.path.dirname(__file__), ".env"))
+
+import database  # noqa: E402  (service-role client)
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+CANONICAL_TYPES = frozenset([
+    "government", "semi_official", "cultural_institution", "academic",
+    "commercial_brand", "independent_venue", "civic_group", "media",
+    "individual", "unknown",
+])
+
+# role -> (names_column, types_column). types_column is also the
+# field_corrections.field_name that protects that array.
+ROLES = (
+    ("co", "co_organizers", "co_organizer_types"),
+    ("sponsor", "sponsors", "sponsor_types"),
+)
+_FC_FIELDS = frozenset(tc for _, _, tc in ROLES)
+
+
+def _card(x) -> int:
+    """COALESCE(cardinality(x), 0) — None and [] both -> 0."""
+    return len(x or [])
+
+
+def _fetch_all_events(sb) -> list[dict[str, Any]]:
+    """Fetch ALL events (active + inactive).
+
+    The Phase B cardinality CHECK is table-wide, so pre-migration remediation
+    must align every row regardless of is_active — inactive mismatches would
+    otherwise block the validated constraint.
+    """
+    cols = (
+        "id,is_active,source_url,co_organizers,co_organizer_types,"
+        "sponsors,sponsor_types"
+    )
+    rows: list[dict[str, Any]] = []
+    offset = 0
+    while True:
+        batch = (
+            sb.table("events").select(cols)
+            .order("id")
+            .range(offset, offset + 999)
+            .execute()
+            .data or []
+        )
+        rows.extend(batch)
+        if len(batch) < 1000:
+            break
+        offset += 1000
+    return rows
+
+
+def _load_fc_protected(sb) -> dict[str, dict[str, str]]:
+    """event_id -> {field_name: corrected_value} for the two type arrays only."""
+    out: dict[str, dict[str, str]] = {}
+    offset = 0
+    while True:
+        rows = (
+            sb.table("field_corrections")
+            .select("event_id,field_name,corrected_value")
+            .in_("field_name", list(_FC_FIELDS))
+            .range(offset, offset + 999)
+            .execute()
+            .data or []
+        )
+        if not rows:
+            break
+        for r in rows:
+            eid = r.get("event_id")
+            fname = r.get("field_name")
+            if eid and fname:
+                out.setdefault(eid, {})[fname] = r.get("corrected_value") or ""
+        if len(rows) < 1000:
+            break
+        offset += 1000
+    return out
+
+
+def _plan(names, types) -> tuple[Any, str, list[str]]:
+    """Return (proposed_type_array, direction, per-index reasons)."""
+    if names is None:
+        return None, "names_null_clear", ["names is NULL -> type array set NULL"]
+    if len(names) == 0:
+        return [], "names_empty_clear", ["names is [] -> type array set []"]
+
+    reasons: list[str] = []
+    new: list[str] = []
+    for i in range(len(names)):
+        existing = types[i] if (types and i < len(types)) else None
+        if existing in CANONICAL_TYPES:
+            new.append(existing)
+            reasons.append(f"[{i}] keep existing valid '{existing}'")
+        else:
+            new.append("unknown")
+            reasons.append(
+                f"[{i}] {'missing' if existing is None else f'invalid {existing!r}'} -> 'unknown'"
+            )
+
+    orphans = list((types or [])[len(names):])
+    if orphans:
+        return new, "types_longer_orphan", reasons + [
+            f"ORPHAN types beyond names: {orphans} -> MANUAL review (not auto-truncated)"
+        ]
+    return new, "types_shorter_pad", reasons
+
+
+def _apply_row(sb, eid: str, names_col: str, types_col: str, new_types) -> bool:
+    """Apply one repair and read back; return True iff cardinality now aligns."""
+    sb.table("events").update({types_col: new_types}).eq("id", eid).execute()
+    rb = (
+        sb.table("events").select(f"id,{names_col},{types_col}")
+        .eq("id", eid).execute().data
+    )
+    if not rb:
+        return False
+    row = rb[0]
+    return _card(row.get(names_col)) == _card(row.get(types_col))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--apply", action="store_true",
+                        help="Apply auto-fixable repairs + read-back (NOT run this batch).")
+    parser.add_argument("--out", default="/tmp",
+                        help="Directory for the dry-run JSON manifest (default /tmp).")
+    parser.add_argument("--limit", type=int, default=0,
+                        help="Cap processed events (0 = all).")
+    args = parser.parse_args()
+
+    sb = database._get_client()
+    logger.info("Fetching ALL events (paginated; table-wide scope)…")
+    events = _fetch_all_events(sb)
+    if args.limit:
+        events = events[: args.limit]
+    fc_map = _load_fc_protected(sb)
+    logger.info("Events scanned: %d | events with co/sponsor-type FC: %d",
+                len(events), len(fc_map))
+
+    manifest: list[dict[str, Any]] = []
+    for ev in events:
+        eid = ev.get("id")
+        for role, names_col, types_col in ROLES:
+            names = ev.get(names_col)
+            types = ev.get(types_col)
+            if _card(names) == _card(types):
+                continue  # aligned — nothing to do
+
+            fc_val = fc_map.get(eid, {}).get(types_col)
+            new_types, direction, reasons = _plan(names, types)
+            if fc_val is not None:
+                category = "fc_protected"
+            elif direction == "types_longer_orphan":
+                category = "manual_orphan"
+            else:
+                category = "auto"
+
+            manifest.append({
+                "event_id": eid,
+                "is_active": bool(ev.get("is_active")),
+                "role": role,
+                "names": names,
+                "current_types": types,
+                "names_card": _card(names),
+                "types_card": _card(types),
+                "proposed_types": new_types,
+                "direction": direction,
+                "category": category,
+                "fc_protected": fc_val is not None,
+                "fc_value": fc_val,
+                "source_url": ev.get("source_url"),
+                "reasons": reasons,
+            })
+
+    # ---- distribution ----
+    events_hit = {m["event_id"] for m in manifest}
+    by_role = Counter(m["role"] for m in manifest)
+    by_cat = Counter(m["category"] for m in manifest)
+    by_dir = Counter(m["direction"] for m in manifest)
+    by_active = Counter("active" if m["is_active"] else "inactive" for m in manifest)
+    fc_pairs = sum(1 for m in manifest if m["fc_protected"])
+
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    os.makedirs(args.out, exist_ok=True)
+    out_path = os.path.join(args.out, f"organizer_type_array_repair_{ts}.json")
+    with open(out_path, "w", encoding="utf-8") as fh:
+        json.dump({
+            "generated_at": ts,
+            "mode": "apply" if args.apply else "dry-run",
+            "events_scanned": len(events),
+            "mismatch_pairs": len(manifest),
+            "mismatch_events": len(events_hit),
+            "by_role": dict(by_role),
+            "by_category": dict(by_cat),
+            "by_direction": dict(by_dir),
+            "by_active": dict(by_active),
+            "fc_protected_pairs": fc_pairs,
+            "rows": manifest,
+        }, fh, ensure_ascii=False, indent=2)
+
+    logger.info("=" * 72)
+    logger.info("PARALLEL TYPE-ARRAY REPAIR  (%s)", "APPLY" if args.apply else "DRY-RUN")
+    logger.info("  events scanned          : %d (table-wide: active + inactive)", len(events))
+    logger.info("  mismatch (event,role)   : %d", len(manifest))
+    logger.info("  distinct events         : %d", len(events_hit))
+    logger.info("  by role                 : %s", dict(by_role))
+    logger.info("  by category             : %s", dict(by_cat))
+    logger.info("  by direction            : %s", dict(by_dir))
+    logger.info("  by is_active            : %s", dict(by_active))
+    logger.info("  FC-protected pairs      : %d", fc_pairs)
+    logger.info("  JSON manifest           : %s", out_path)
+    logger.info("-" * 72)
+    for m in manifest[:40]:
+        logger.info(
+            "  %s %s %-7s %-18s names=%s(%d) types=%s(%d) -> %s  fc=%s",
+            "A" if m["is_active"] else "I",
+            m["event_id"][:8], m["role"], m["category"],
+            m["names"], m["names_card"], m["current_types"], m["types_card"],
+            m["proposed_types"], m["fc_protected"],
+        )
+    if len(manifest) > 40:
+        logger.info("  … %d more (see JSON manifest)", len(manifest) - 40)
+
+    if not args.apply:
+        logger.info("-" * 72)
+        logger.info("DRY-RUN — no database writes. Re-run with --apply after human "
+                    "approval to fix 'auto' rows (manual_orphan / fc_protected are skipped).")
+        return
+
+    # ---- apply path (only 'auto' rows; read-back each) ----
+    logger.info("-" * 72)
+    logger.info("APPLYING auto-fixable repairs…")
+    ok = fail = 0
+    role_cols = {role: (nc, tc) for role, nc, tc in ROLES}
+    for m in manifest:
+        if m["category"] != "auto":
+            continue
+        names_col, types_col = role_cols[m["role"]]
+        verified = _apply_row(sb, m["event_id"], names_col, types_col, m["proposed_types"])
+        if verified:
+            ok += 1
+            logger.info("  db=✓ %s %s -> %s", m["event_id"][:8], m["role"], m["proposed_types"])
+        else:
+            fail += 1
+            logger.warning("  db=✗ %s %s read-back mismatch", m["event_id"][:8], m["role"])
+    logger.info("APPLY complete: ok=%d fail=%d (manual_orphan + fc_protected left for human review)",
+                ok, fail)
+
+
+if __name__ == "__main__":
+    main()

--- a/scraper/annotator.py
+++ b/scraper/annotator.py
@@ -43,6 +43,7 @@ from category_feedback import load_corrections, build_feedback_prompt
 from selection_reason_feedback import load_sr_corrections, build_sr_feedback_prompt
 from movie_title_lookup import lookup_movie_titles, lookup_movie_titles_with_metadata
 from venue_registry import lookup_venue
+from organizer_registry import lookup_organizer
 from security.injection_guard import (
     scan_for_injection,
     finding_fingerprint,
@@ -1740,6 +1741,104 @@ def _apply_small_venue_organizer_fallback(
     if "organizer_type" not in protected_fields and (not current_type or current_type == ["unknown"]):
         update_data["organizer_type"] = ["cultural_institution" if is_cultural else "independent_venue"]
 
+
+def _apply_organizer_registry(
+    event: dict[str, Any],
+    data: dict[str, Any],
+    protected_fields: "dict[str, str] | set[str] | None" = None,
+) -> None:
+    """Overlay verified organizer-registry types onto assembled annotation data.
+
+    Runs AFTER the LLM result is assembled into ``data`` and BEFORE the
+    field_corrections restore, so the authority order stays
+    ``FC > registry > source default > existing > LLM``. Only the *type*
+    fields (``organizer_type`` / ``co_organizer_types`` / ``sponsor_types``)
+    are touched — the raw ``organizer`` / ``co_organizers`` / ``sponsors``
+    name text is never rewritten.
+
+    Graceful degradation: until migration 095 is applied, ``lookup_organizer``
+    returns ``None`` for every name, so every branch below is a no-op and
+    ``data`` is left field-for-field identical to the pre-registry state
+    (registry no-op == zero behaviour change).
+    """
+    protected_fields = protected_fields or {}
+
+    # ---- Primary organizer_type: scalar registry value → events.text[] field ----
+    if "organizer_type" not in protected_fields:
+        primary_name = data.get("organizer") or event.get("organizer")
+        entity = lookup_organizer(primary_name) if primary_name else None
+        registry_type = entity.get("organizer_type") if entity else None
+        if (
+            isinstance(registry_type, str)
+            and registry_type in VALID_ORGANIZER_TYPES
+            and registry_type != "unknown"
+        ):
+            current = data.get("organizer_type")
+            if current is None:
+                current = event.get("organizer_type") or []
+            valid = [
+                t for t in current
+                if isinstance(t, str) and t in VALID_ORGANIZER_TYPES and t != "unknown"
+            ]
+            if not valid:
+                # (a) empty / all-unknown → adopt registry type.
+                data["organizer_type"] = [registry_type]
+            elif registry_type in valid:
+                # (b) already contains registry type → preserve as-is (no flatten/reorder).
+                pass
+            elif len(valid) == 1:
+                # (c) single conflicting valid type → registry wins; record conflict.
+                logger.info(
+                    "organizer_registry primary conflict: organizer=%r had %s, "
+                    "registry=%s → overriding with registry type",
+                    primary_name, valid, registry_type,
+                )
+                data["organizer_type"] = [registry_type]
+            else:
+                # (d) >=2 valid types, none is the registry type → fail closed.
+                logger.warning(
+                    "organizer_registry primary manual-conflict-queue: organizer=%r "
+                    "has multi-type %s, registry=%s → preserving original array "
+                    "(no auto-flatten)",
+                    primary_name, valid, registry_type,
+                )
+
+    # ---- Co-organizer / Sponsor parallel arrays: per-index type overlay ----
+    # Only rebuild a type array when the registry resolves at least one index; a
+    # fully-missing registry leaves the array untouched (graceful no-op) so the
+    # pre-existing cardinality is preserved for the A.5 / migration-095 path.
+    for _names_field, _types_field in (
+        ("co_organizers", "co_organizer_types"),
+        ("sponsors", "sponsor_types"),
+    ):
+        if _types_field in protected_fields:
+            continue
+        names = data.get(_names_field)
+        if not isinstance(names, list) or not names:
+            continue
+        existing_types = data.get(_types_field) or []
+        rebuilt: list[str] = []
+        registry_touched = False
+        for i, nm in enumerate(names):
+            prev = existing_types[i] if i < len(existing_types) else None
+            prev = prev if (isinstance(prev, str) and prev in VALID_ORGANIZER_TYPES) else "unknown"
+            entity = lookup_organizer(nm) if isinstance(nm, str) and nm else None
+            registry_type = entity.get("organizer_type") if entity else None
+            if (
+                isinstance(registry_type, str)
+                and registry_type in VALID_ORGANIZER_TYPES
+                and registry_type != "unknown"
+            ):
+                rebuilt.append(registry_type)
+                registry_touched = True
+            else:
+                rebuilt.append(prev)
+        if registry_touched:
+            # Registry wrote at least one index → guarantee cardinality parity
+            # (cardinality(names) == cardinality(types)) per migration 095 CHECK.
+            data[_types_field] = rebuilt
+
+
 _TV_PROGRAM_KEYWORDS = frozenset(["放送:", "放送：", "ジャンル:", "ジャンル："])
 
 # Report article detection: these keywords in raw_title or raw_description
@@ -1763,7 +1862,12 @@ _REPORT_PREFIXES: dict[str, str] = {
 _NON_TEXT_FC_FIELDS = {
     "category", "event_form", "performers",
     "performers_zh", "performers_en",
-    "location_prefectures", "organizer_type", "co_organizers",
+    "location_prefectures", "organizer_type",
+    # co-organizer / sponsor name + parallel type arrays are all DB-native
+    # list columns; keep them symmetric so a TEXT corrected_value never
+    # pollutes a text[] column (DB-native restore instead).
+    "co_organizers", "co_organizer_types",
+    "sponsors", "sponsor_types",
     "is_paid", "is_active",
     "selection_reason",
 }
@@ -2821,6 +2925,13 @@ def annotate_pending_events(
                     selection_reason = json.dumps(selection_reason, ensure_ascii=False)
                 update_data["selection_reason"] = selection_reason
 
+            # Authoritative organizer registry: overlay verified entity types onto
+            # organizer_type / co_organizer_types / sponsor_types AFTER LLM assembly
+            # and BEFORE the field_corrections restore below, keeping the authority
+            # order FC > registry > source default > existing > LLM. No-op until
+            # migration 095 seeds authoritative rows (lookup_organizer → None).
+            _apply_organizer_registry(event, update_data, _human_protected)
+
             # P1 field-protection: restore DB values for any field in field_corrections.
             # _ai_or_existing() was defined but never wired into update_data construction.
             # This post-processing step closes the gap: after GPT fills update_data,
@@ -3124,6 +3235,7 @@ def annotate_pending_events(
                     }
 
                     _sub_protected = human_field_map.get(_prev.get("id") if _prev else "", {})
+                    _apply_organizer_registry(_prev or {}, sub_row, _sub_protected)
                     for _pf, _fc_val in _sub_protected.items():
                         if _pf in sub_row:
                             if _pf in _NON_TEXT_FC_FIELDS:

--- a/scraper/audit_organizers.py
+++ b/scraper/audit_organizers.py
@@ -1,0 +1,442 @@
+#!/usr/bin/env python3
+"""
+Organizer Authority — Phase A audit manifest (READ-ONLY).
+
+Scans every active event and groups the primary organizer, each co-organizer,
+and each sponsor by a *normalized exact name* so a human can review entity
+identity before any registry seed. This tool NEVER writes to the database — it
+only emits a JSON + CSV manifest (to --out-dir, default /tmp).
+
+Normalization (deliberately conservative — "normalized exact name", NOT the
+aggressive fuzzy clustering in merger._normalize which strips year/subtitle
+suffixes and all internal whitespace):
+  - NFKC (unifies full-width / half-width, e.g. （ＡＢＣ） -> (ABC))
+  - trim
+  - strip leading/trailing wrapping brackets / quotes
+  - collapse internal whitespace runs to a single space
+  - casefold (Latin case-insensitive; CJK unaffected)
+
+The most common raw spelling in a group is the canonical candidate; other raw
+spellings are recorded as aliases. Keyword lists are used ONLY for candidate
+discovery (which entities a human should look at first) and never assign a
+final organizer_type.
+
+Priority cohorts:
+  A1  department store / mall / bookstore chain / retail brand candidates
+  A2  organizers of active event_form=market events (named entity vs
+      organizer-null reported separately)
+  A3  cultural_institution vs independent_venue boundary (same name carries
+      both types)
+  A4  same name across multiple types, alias-link candidates (containment),
+      and parallel co/sponsor type-array cardinality mismatches
+
+Usage:
+    python audit_organizers.py                     # dry-run manifest to /tmp
+    python audit_organizers.py --out-dir .         # write manifest to cwd
+    python audit_organizers.py --top 30            # more console samples
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import logging
+import os
+import re
+import unicodedata
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from typing import Any
+
+from dotenv import load_dotenv
+
+load_dotenv(os.path.join(os.path.dirname(__file__), ".env"))
+
+import database  # noqa: E402  (service-role client; READ-ONLY usage here)
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+# Canonical storage vocabulary (10 values). Used only to distinguish
+# "meaningful" types from null/unknown when detecting drift — NOT to classify.
+CANONICAL_TYPES = frozenset([
+    "government", "semi_official", "cultural_institution", "academic",
+    "commercial_brand", "independent_venue", "civic_group", "media",
+    "individual", "unknown",
+])
+_MEANINGFUL = CANONICAL_TYPES - {"unknown"}
+
+# --- Keyword cohorts (CANDIDATE DISCOVERY ONLY — never final classification) --
+_KW_DEPT = [
+    "高島屋", "髙島屋", "三越", "伊勢丹", "大丸", "松坂屋", "そごう", "西武",
+    "阪急", "阪神", "近鉄", "京王", "小田急", "東武", "名鉄", "百貨店", "百貨",
+]
+_KW_MALL = [
+    "パルコ", "PARCO", "ルミネ", "LUMINE", "アトレ", "atre", "丸井", "マルイ",
+    "OIOI", "ラゾーナ", "ららぽーと", "LaLaport", "イオン", "AEON", "モール",
+    "ショッピング", "アウトレット", "商業施設", "テラスモール",
+]
+_KW_BOOKSTORE = [
+    "蔦屋", "TSUTAYA", "紀伊國屋", "紀伊国屋", "ジュンク堂", "丸善", "有隣堂",
+    "誠品", "三省堂", "未来屋書店", "くまざわ", "文教堂", "書店", "ブックセンター",
+]
+_KW_RETAIL = [
+    "ストア", "STORE", "ショップ", "SHOP", "専門店", "セレクトショップ",
+]
+# Informational only — corporate legal form is a weak signal and does NOT
+# trigger A1 by itself (many civic groups / presses are also 株式会社).
+_KW_CORP_FORM = [
+    "株式会社", "有限会社", "合同会社", "(株)", "(有)", "Inc", "Ltd", "LLC", "Corp",
+]
+
+_WRAP_OPEN = set("「『《〈【〔｛（(【[{＜<“‘\"'`")
+_WRAP_CLOSE = set("」』》〉】〕｝）)]}＞>”’\"'`")
+
+
+def _norm_key(name: str | None) -> str:
+    """Conservative 'normalized exact name' key (see module docstring)."""
+    if not name:
+        return ""
+    s = unicodedata.normalize("NFKC", name).strip()
+    prev = None
+    while prev != s and s:
+        prev = s
+        if s and s[0] in _WRAP_OPEN:
+            s = s[1:].strip()
+        if s and s[-1] in _WRAP_CLOSE:
+            s = s[:-1].strip()
+    s = re.sub(r"[\s\u3000\u00a0]+", " ", s)
+    return s.casefold()
+
+
+def _kw_hits(raw_forms: list[str]) -> dict[str, list[str]]:
+    """Return {signal: [matched keywords]} across all raw spellings of an entity."""
+    joined = " ".join(raw_forms).lower()
+    out: dict[str, list[str]] = {}
+    for signal, kws in (
+        ("dept", _KW_DEPT), ("mall", _KW_MALL),
+        ("bookstore", _KW_BOOKSTORE), ("retail", _KW_RETAIL),
+        ("corp_form", _KW_CORP_FORM),
+    ):
+        hits = [k for k in kws if k.lower() in joined]
+        if hits:
+            out[signal] = hits
+    return out
+
+
+def _fetch_all_active_events(sb) -> list[dict[str, Any]]:
+    """Paginated fetch of all active events (PostgREST caps at 1000/req)."""
+    cols = (
+        "id,organizer,organizer_type,co_organizers,co_organizer_types,"
+        "sponsors,sponsor_types,event_form,source_name,source_url"
+    )
+    rows: list[dict[str, Any]] = []
+    offset = 0
+    while True:
+        batch = (
+            sb.table("events").select(cols)
+            .eq("is_active", True)
+            .order("id")
+            .range(offset, offset + 999)
+            .execute()
+            .data or []
+        )
+        rows.extend(batch)
+        if len(batch) < 1000:
+            break
+        offset += 1000
+    return rows
+
+
+def _iter_entities(ev: dict[str, Any]):
+    """Yield (raw_name, role, type_value) for every organizer entity in one event.
+
+    - primary: organizer (single string) -> every value in organizer_type[]
+    - co:      co_organizers[i] -> co_organizer_types[i]
+    - sponsor: sponsors[i]      -> sponsor_types[i]
+    """
+    org = (ev.get("organizer") or "").strip()
+    if org:
+        otypes = ev.get("organizer_type") or []
+        if otypes:
+            for t in otypes:
+                yield org, "primary", t
+        else:
+            yield org, "primary", None
+
+    for names_col, types_col, role in (
+        ("co_organizers", "co_organizer_types", "co"),
+        ("sponsors", "sponsor_types", "sponsor"),
+    ):
+        names = ev.get(names_col) or []
+        types = ev.get(types_col) or []
+        for i, nm in enumerate(names):
+            nm = (nm or "").strip()
+            if not nm:
+                continue
+            t = types[i] if i < len(types) else None
+            yield nm, role, t
+
+
+def _card(x) -> int:
+    """COALESCE(cardinality(x), 0) — None and [] both -> 0."""
+    return len(x or [])
+
+
+def build_manifest(events: list[dict[str, Any]], sample_urls: int) -> dict[str, Any]:
+    groups: dict[str, dict[str, Any]] = {}
+    market_null_events: list[str] = []
+
+    for ev in events:
+        eid = ev.get("id")
+        src = ev.get("source_name")
+        url = ev.get("source_url")
+        forms = set(ev.get("event_form") or [])
+        is_market = "market" in forms
+
+        if is_market and not (ev.get("organizer") or "").strip():
+            market_null_events.append(eid)
+
+        for raw, role, t in _iter_entities(ev):
+            key = _norm_key(raw)
+            if not key:
+                continue
+            g = groups.get(key)
+            if g is None:
+                g = groups[key] = {
+                    "normalized_key": key,
+                    "raw_forms": Counter(),
+                    "roles": set(),
+                    "types_by_role": defaultdict(Counter),
+                    "event_ids": set(),
+                    "sources": set(),
+                    "evidence": [],
+                    "market_primary_count": 0,
+                }
+            g["raw_forms"][raw] += 1
+            g["roles"].add(role)
+            g["types_by_role"][role][t if t is not None else "(null)"] += 1
+            if eid:
+                g["event_ids"].add(eid)
+            if src:
+                g["sources"].add(src)
+            if role == "primary" and is_market:
+                g["market_primary_count"] += 1
+            if url and len(g["evidence"]) < sample_urls and all(
+                url != e["source_url"] for e in g["evidence"]
+            ):
+                g["evidence"].append({"event_id": eid, "source_url": url})
+
+    # Finalize entity records + cohort tagging.
+    entities: list[dict[str, Any]] = []
+    for key, g in groups.items():
+        raw_forms_sorted = g["raw_forms"].most_common()
+        canonical = raw_forms_sorted[0][0]
+        aliases = [{"name": n, "count": c} for n, c in raw_forms_sorted[1:]]
+        all_types = set()
+        for role_ctr in g["types_by_role"].values():
+            all_types.update(role_ctr.keys())
+        distinct_meaningful = sorted(t for t in all_types if t in _MEANINGFUL)
+
+        kw = _kw_hits([n for n, _ in raw_forms_sorted])
+        cohorts: list[str] = []
+        if any(s in kw for s in ("dept", "mall", "bookstore", "retail")):
+            cohorts.append("A1")
+        if g["market_primary_count"] > 0:
+            cohorts.append("A2")
+        if "cultural_institution" in all_types and "independent_venue" in all_types:
+            cohorts.append("A3")
+        if len(distinct_meaningful) >= 2:
+            cohorts.append("A4-multitype")
+        # cross-role divergence: entity plays >=2 roles and meaningful types differ
+        if len(g["roles"]) >= 2:
+            role_meaningful = {
+                role: sorted(t for t in ctr if t in _MEANINGFUL)
+                for role, ctr in g["types_by_role"].items()
+            }
+            nonempty = [tuple(v) for v in role_meaningful.values() if v]
+            if len(set(nonempty)) >= 2:
+                cohorts.append("A4-crossrole")
+
+        entities.append({
+            "normalized_key": key,
+            "canonical": canonical,
+            "aliases": aliases,
+            "n_raw_forms": len(raw_forms_sorted),
+            "roles": sorted(g["roles"]),
+            "event_count": len(g["event_ids"]),
+            "sources": sorted(g["sources"]),
+            "types_by_role": {
+                role: dict(ctr) for role, ctr in g["types_by_role"].items()
+            },
+            "distinct_meaningful_types": distinct_meaningful,
+            "keyword_signals": kw,
+            "market_primary_count": g["market_primary_count"],
+            "cohorts": cohorts,
+            "evidence": g["evidence"],
+        })
+
+    entities.sort(key=lambda e: (-e["event_count"], e["normalized_key"]))
+
+    # Alias-link candidates (A4 alias-collision proxy): containment between two
+    # distinct normalized keys of named entities with DIFFERENT meaningful type
+    # sets. Exact-name grouping cannot produce a literal shared alias, so this
+    # surfaces likely same-entity naming inconsistencies for human review only.
+    alias_candidates: list[dict[str, Any]] = []
+    review_pool = [
+        e for e in entities
+        if e["event_count"] >= 2 or e["cohorts"] or e["distinct_meaningful_types"]
+    ]
+    keys = [e["normalized_key"] for e in review_pool]
+    by_key = {e["normalized_key"]: e for e in review_pool}
+    for a in keys:
+        if len(a) < 3:
+            continue
+        for b in keys:
+            if a == b or len(b) <= len(a):
+                continue
+            if a in b:
+                ta = set(by_key[a]["distinct_meaningful_types"])
+                tb = set(by_key[b]["distinct_meaningful_types"])
+                if ta and tb and ta != tb:
+                    alias_candidates.append({
+                        "shorter": by_key[a]["canonical"],
+                        "shorter_types": sorted(ta),
+                        "longer": by_key[b]["canonical"],
+                        "longer_types": sorted(tb),
+                    })
+        if len(alias_candidates) >= 200:
+            break
+
+    # Parallel-array cardinality mismatch events (A4 mismatch; cross-ref A.5).
+    mismatch_events: list[dict[str, Any]] = []
+    for ev in events:
+        co_mm = _card(ev.get("co_organizers")) != _card(ev.get("co_organizer_types"))
+        sp_mm = _card(ev.get("sponsors")) != _card(ev.get("sponsor_types"))
+        if co_mm or sp_mm:
+            roles = []
+            if co_mm:
+                roles.append("co")
+            if sp_mm:
+                roles.append("sponsor")
+            mismatch_events.append({"event_id": ev.get("id"), "roles": roles})
+
+    return {
+        "entities": entities,
+        "alias_link_candidates": alias_candidates,
+        "market_null_events": market_null_events,
+        "mismatch_events": mismatch_events,
+    }
+
+
+def _cohort_counts(entities: list[dict[str, Any]]) -> Counter:
+    c: Counter = Counter()
+    for e in entities:
+        for tag in e["cohorts"]:
+            c[tag] += 1
+    return c
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--out-dir", default="/tmp",
+                        help="Directory for JSON + CSV manifest (default /tmp).")
+    parser.add_argument("--sample-urls", type=int, default=3,
+                        help="Evidence source_urls to keep per entity (default 3).")
+    parser.add_argument("--top", type=int, default=20,
+                        help="Console sample rows per cohort (default 20).")
+    args = parser.parse_args()
+
+    sb = database._get_client()
+    logger.info("Fetching active events (paginated)…")
+    events = _fetch_all_active_events(sb)
+    logger.info("Active events fetched: %d", len(events))
+
+    manifest = build_manifest(events, args.sample_urls)
+    entities = manifest["entities"]
+    counts = _cohort_counts(entities)
+
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    os.makedirs(args.out_dir, exist_ok=True)
+    json_path = os.path.join(args.out_dir, f"organizer_audit_{ts}.json")
+    csv_path = os.path.join(args.out_dir, f"organizer_audit_{ts}.csv")
+
+    with open(json_path, "w", encoding="utf-8") as fh:
+        json.dump({
+            "generated_at": ts,
+            "active_events": len(events),
+            "entity_count": len(entities),
+            "cohort_counts": dict(counts),
+            "alias_link_candidate_count": len(manifest["alias_link_candidates"]),
+            "market_null_event_count": len(manifest["market_null_events"]),
+            "parallel_array_mismatch_active_event_count": len(manifest["mismatch_events"]),
+            "parallel_array_mismatch_note": (
+                "active-scope only; authoritative table-wide scan lives in "
+                "_oneoff_repair_organizer_type_arrays.py (Phase A.5)"
+            ),
+            **manifest,
+        }, fh, ensure_ascii=False, indent=2)
+
+    with open(csv_path, "w", encoding="utf-8", newline="") as fh:
+        w = csv.writer(fh)
+        w.writerow([
+            "normalized_key", "canonical", "n_raw_forms", "event_count",
+            "roles", "distinct_meaningful_types", "cohorts",
+            "market_primary_count", "keyword_signals", "sources",
+            "sample_source_urls",
+        ])
+        for e in entities:
+            w.writerow([
+                e["normalized_key"], e["canonical"], e["n_raw_forms"],
+                e["event_count"], "|".join(e["roles"]),
+                "|".join(e["distinct_meaningful_types"]),
+                "|".join(e["cohorts"]), e["market_primary_count"],
+                ";".join(f"{k}:{','.join(v)}" for k, v in e["keyword_signals"].items()),
+                "|".join(e["sources"]),
+                " ".join(ev["source_url"] for ev in e["evidence"]),
+            ])
+
+    # ---- Console summary ----
+    logger.info("=" * 72)
+    logger.info("ORGANIZER AUDIT MANIFEST  (READ-ONLY — no DB writes)")
+    logger.info("  active events        : %d", len(events))
+    logger.info("  distinct entities    : %d", len(entities))
+    logger.info("  JSON manifest        : %s", json_path)
+    logger.info("  CSV manifest         : %s", csv_path)
+    logger.info("-" * 72)
+    logger.info("COHORT COUNTS")
+    for tag in ("A1", "A2", "A3", "A4-multitype", "A4-crossrole"):
+        logger.info("  %-14s : %d", tag, counts.get(tag, 0))
+    logger.info("  %-14s : %d", "alias-link cand", len(manifest["alias_link_candidates"]))
+    logger.info("  %-14s : %d", "market-null ev", len(manifest["market_null_events"]))
+    logger.info("  %-14s : %d (active-scope; Phase A.5 = full table)",
+                "parallel mm ev", len(manifest["mismatch_events"]))
+
+    def _show(tag: str) -> None:
+        rows = [e for e in entities if tag in e["cohorts"]][: args.top]
+        logger.info("-" * 72)
+        logger.info("%s — top %d by event_count", tag, len(rows))
+        for e in rows:
+            logger.info(
+                "  [%2d ev] %-30s roles=%s types=%s kw=%s",
+                e["event_count"], e["canonical"][:30], ",".join(e["roles"]),
+                ",".join(e["distinct_meaningful_types"]) or "-",
+                ",".join(e["keyword_signals"].keys()) or "-",
+            )
+
+    for tag in ("A1", "A2", "A3", "A4-multitype", "A4-crossrole"):
+        _show(tag)
+
+    if manifest["alias_link_candidates"]:
+        logger.info("-" * 72)
+        logger.info("ALIAS-LINK CANDIDATES (containment; review-only) — top %d",
+                    min(args.top, len(manifest["alias_link_candidates"])))
+        for c in manifest["alias_link_candidates"][: args.top]:
+            logger.info("  '%s' %s  ⊂  '%s' %s",
+                        c["shorter"][:24], c["shorter_types"],
+                        c["longer"][:24], c["longer_types"])
+
+
+if __name__ == "__main__":
+    main()

--- a/scraper/backfill_organizer_authority.py
+++ b/scraper/backfill_organizer_authority.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Backfill organizer authority — Wave 2 Phase D (registry backfill, dry-run first).
+
+Re-resolves the organizer *type* fields of active events against the
+authoritative organizer registry, reusing the exact same logic the daily
+annotator applies (``annotator._apply_organizer_registry``) so there is a
+single source of truth for the scalar→array four-case protection — no
+duplicated logic, no drift.
+
+Per event it also sets ``organizer_id`` when the primary organizer name
+resolves to an authoritative entity (the annotator helper only refines types;
+FK population lives in ``database._populate_entity_fks``, mirrored here).
+
+⛔ SCOPE — this batch is CODE-ONLY: the default mode is ``--dry-run`` and NO
+row is ever written unless ``--apply`` is passed. The real backfill is
+production gate 2C; do NOT run ``--apply`` here.
+
+Graceful degradation (migration 095 not yet applied)
+----------------------------------------------------
+The registry loads only ``organizers`` rows flagged ``is_authoritative``. That
+column ships in migration 095; before it is applied ``lookup_organizer``
+returns ``None`` for every name (empty registry), so every event is an exact
+no-op and the dry-run reports zero coverage. That is the expected pre-gate
+state — the backfill only has effect once gate 2C has seeded authoritative rows.
+
+Authority order preserved
+-------------------------
+``FC > registry > source default > existing > LLM``. Fields locked by
+``field_corrections`` are skipped and counted; they are never overwritten.
+
+Four-case primary protection (delegated to the annotator helper)
+----------------------------------------------------------------
+(a) empty / all-unknown  → adopt registry type;
+(b) already contains it  → preserve verbatim (no flatten/reorder);
+(c) single conflict      → registry wins (counted);
+(d) ≥2 valid, none match → fail closed, keep original array + manual queue.
+
+Usage::
+
+    python backfill_organizer_authority.py            # dry-run (default)
+    python backfill_organizer_authority.py --apply    # gate 2C ONLY
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import logging
+import os
+from typing import Any
+
+from dotenv import load_dotenv
+
+import annotator
+from annotator import _apply_organizer_registry, _load_human_field_map
+from database import _get_client
+from organizer_registry import lookup_organizer, reset_cache
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+# Type fields refined by the registry (parallel to the name fields).
+TYPE_FIELDS = ("organizer_type", "co_organizer_types", "sponsor_types")
+# FC-protectable fields relevant to this backfill.
+_FC_RELEVANT = TYPE_FIELDS + ("organizer_id", "organizer")
+
+_EVENT_COLUMNS = (
+    "id,organizer,organizer_id,organizer_type,"
+    "co_organizers,co_organizer_types,sponsors,sponsor_types"
+)
+
+
+def fetch_active_events(sb: Any) -> list[dict[str, Any]]:
+    """Return all active events (paginated; Supabase caps at 1000/call)."""
+    out: list[dict[str, Any]] = []
+    offset = 0
+    while True:
+        rows = (
+            sb.table("events")
+            .select(_EVENT_COLUMNS)
+            .eq("is_active", True)
+            .range(offset, offset + 999)
+            .execute()
+            .data
+            or []
+        )
+        if not rows:
+            break
+        out.extend(rows)
+        if len(rows) < 1000:
+            break
+        offset += 1000
+    return out
+
+
+def build_working_data(event: dict[str, Any]) -> dict[str, Any]:
+    """Copy the organizer name + type fields into a mutable working dict.
+
+    Deep-copies list values so mutation by the annotator helper never touches
+    the source event row.
+    """
+    fields = (
+        "organizer", "organizer_type",
+        "co_organizers", "co_organizer_types",
+        "sponsors", "sponsor_types",
+    )
+    return {f: copy.deepcopy(event.get(f)) for f in fields}
+
+
+def _count_unknowns(data: dict[str, Any]) -> int:
+    """Count ``unknown`` entries across the co/sponsor type arrays."""
+    total = 0
+    for field in ("co_organizer_types", "sponsor_types"):
+        for t in data.get(field) or []:
+            if t == "unknown":
+                total += 1
+    return total
+
+
+def _detect_primary_conflict(
+    event: dict[str, Any],
+    before_type: list[str] | None,
+    fc_fields: set[str],
+    hit: dict[str, Any] | None,
+) -> bool:
+    """Report-only detection of the four-case (d) fail-closed manual-queue case.
+
+    Mirrors — for counting only — the branch inside
+    ``_apply_organizer_registry``: a registry hit whose scalar type conflicts
+    with an existing multi-type (≥2 valid) array that does not contain it. The
+    actual write decision is still owned by the annotator helper; this only
+    classifies the outcome for the dry-run report.
+    """
+    if "organizer_type" in fc_fields or not hit:
+        return False
+    rtype = hit.get("organizer_type")
+    if not (
+        isinstance(rtype, str)
+        and rtype in annotator.VALID_ORGANIZER_TYPES
+        and rtype != "unknown"
+    ):
+        return False
+    current = before_type or []
+    valid = [
+        t for t in current
+        if isinstance(t, str) and t in annotator.VALID_ORGANIZER_TYPES and t != "unknown"
+    ]
+    return len(valid) >= 2 and rtype not in valid
+
+
+def plan_event(event: dict[str, Any], fc_fields: set[str]) -> dict[str, Any]:
+    """Compute the registry backfill plan for one event (no DB write).
+
+    Delegates the type mutation to ``annotator._apply_organizer_registry`` and
+    adds the ``organizer_id`` FK the annotator helper does not set.
+    """
+    data = build_working_data(event)
+    before = {f: copy.deepcopy(data.get(f)) for f in TYPE_FIELDS}
+    before_org_id = event.get("organizer_id")
+
+    # Reuse the canonical four-case + per-index overlay logic (single source of
+    # truth). FC-protected type fields are skipped inside the helper.
+    _apply_organizer_registry(event, data, fc_fields)
+
+    # organizer_id FK (registry primary hit) — not handled by the annotator.
+    primary_name = data.get("organizer") or event.get("organizer")
+    hit = lookup_organizer(primary_name) if primary_name else None
+    org_id_change: tuple[Any, Any] | None = None
+    if hit and "organizer_id" not in fc_fields:
+        new_id = hit.get("id")
+        if new_id and new_id != before_org_id:
+            data["organizer_id"] = new_id
+            org_id_change = (before_org_id, new_id)
+
+    after = {f: copy.deepcopy(data.get(f)) for f in TYPE_FIELDS}
+    type_changed = after != before
+    changed = type_changed or org_id_change is not None
+
+    fc_skips = sorted(f for f in _FC_RELEVANT if f in fc_fields)
+    primary_conflict = _detect_primary_conflict(
+        event, before.get("organizer_type"), fc_fields, hit
+    )
+
+    return {
+        "event_id": event.get("id"),
+        "changed": changed,
+        "before": before,
+        "after": after,
+        "org_id_change": org_id_change,
+        "fc_skips": fc_skips,
+        "primary_conflict": primary_conflict,
+        "unknowns": _count_unknowns(data),
+        "registry_hit": bool(hit),
+        "_write": {f: data.get(f) for f in TYPE_FIELDS if after[f] != before[f]}
+        | ({"organizer_id": data.get("organizer_id")} if org_id_change else {}),
+    }
+
+
+def run(dry_run: bool = True, sample: int = 20) -> dict[str, Any]:
+    sb = _get_client()
+    # Rebuild the registry cache against the current DB (empty pre-095).
+    reset_cache()
+
+    events = fetch_active_events(sb)
+    try:
+        fc_map = _load_human_field_map(sb)
+    except Exception as exc:
+        logger.debug("field_corrections unavailable (pre-migration 038b?): %s", exc)
+        fc_map = {}
+
+    plans = [plan_event(ev, set(fc_map.get(ev.get("id"), {}).keys())) for ev in events]
+
+    changed = [p for p in plans if p["changed"]]
+    conflicts = [p for p in plans if p["primary_conflict"]]
+    fc_skipped = [p for p in plans if p["fc_skips"]]
+    total_unknowns = sum(p["unknowns"] for p in plans)
+    registry_hits = sum(1 for p in plans if p["registry_hit"])
+
+    mode = "DRY-RUN" if dry_run else "APPLY"
+    print(f"=== backfill_organizer_authority [{mode}] — {len(events)} active events ===")
+    if registry_hits == 0:
+        print(
+            "[REGISTRY] 0 authoritative hits → registry 為空（migration 095 未 apply "
+            "或尚未 seed authoritative rows）。預期無覆蓋；pre-flight/結構正常。"
+        )
+    else:
+        print(f"[REGISTRY] {registry_hits} event(s) matched an authoritative organizer.")
+
+    print(
+        f"[SUMMARY] changed={len(changed)} primary_conflicts(manual queue)={len(conflicts)} "
+        f"fc_skipped_events={len(fc_skipped)} co/sponsor_unknowns={total_unknowns}"
+    )
+
+    for p in changed[:sample]:
+        print(
+            f"[CHANGE] {p['event_id']}\n"
+            f"    before: {p['before']}\n"
+            f"    after : {p['after']}"
+            + (f"\n    organizer_id: {p['org_id_change'][0]} → {p['org_id_change'][1]}"
+               if p["org_id_change"] else "")
+            + (f"\n    fc_skips: {p['fc_skips']}" if p["fc_skips"] else "")
+        )
+    if conflicts:
+        print(f"\n[MANUAL QUEUE] {len(conflicts)} primary multi-type conflict(s) (fail closed, no auto-flatten):")
+        for p in conflicts[:sample]:
+            print(f"    - {p['event_id']} existing={p['before']['organizer_type']}")
+
+    applied = 0
+    if not dry_run:
+        for p in changed:
+            payload = p["_write"]
+            if not payload:
+                continue
+            sb.table("events").update(payload).eq("id", p["event_id"]).execute()
+            applied += 1
+        print(f"[APPLY] updated {applied} event row(s).")
+
+    return {
+        "events": len(events),
+        "changed": len(changed),
+        "primary_conflicts": len(conflicts),
+        "fc_skipped_events": len(fc_skipped),
+        "unknowns": total_unknowns,
+        "registry_hits": registry_hits,
+        "applied": applied,
+        "plans": plans,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Backfill organizer authority types/FK from the registry (dry-run default)."
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Write refined types/organizer_id to events (gate 2C ONLY).",
+    )
+    parser.add_argument(
+        "--sample", type=int, default=20, help="Console sample rows (default 20)."
+    )
+    args = parser.parse_args()
+
+    load_dotenv(os.path.join(os.path.dirname(__file__), ".env"))
+    run(dry_run=not args.apply, sample=args.sample)
+
+
+if __name__ == "__main__":
+    main()

--- a/scraper/database.py
+++ b/scraper/database.py
@@ -213,22 +213,35 @@ def _populate_entity_fks(client: Client, rows: list[dict]) -> None:
             if still_missing:
                 # `aliases @> ARRAY[…]` via `cs` filter on TEXT[] column.
                 # One round-trip per string (small N expected — usually < 50/run).
+                # No `.limit(1)`: an alias must resolve to exactly one organizer.
+                # If it matches multiple rows the alias is ambiguous — fail closed
+                # (leave organizer_id unset) instead of arbitrarily taking the
+                # first row. Mirrors the organizer_registry duplicate-alias guard.
                 for s in still_missing:
                     try:
                         ar = (
                             client.table("organizers")
                             .select("id,homepage,aliases")
                             .contains("aliases", [s])
-                            .limit(1)
                             .execute()
                         )
-                        if ar.data:
+                        matches = ar.data or []
+                        if len(matches) > 1:
+                            logger.warning(
+                                "organizer alias %r matched %d organizer rows; "
+                                "leaving organizer_id unset (fail closed).",
+                                s,
+                                len(matches),
+                            )
+                            continue
+                        if matches:
+                            hit = matches[0]
                             aliases = tuple(
                                 a
-                                for a in (ar.data[0].get("aliases") or [])
+                                for a in (hit.get("aliases") or [])
                                 if isinstance(a, str) and a.strip()
                             )
-                            org_lookup[s] = (ar.data[0]["id"], ar.data[0].get("homepage"), aliases)
+                            org_lookup[s] = (hit["id"], hit.get("homepage"), aliases)
                     except Exception:
                         pass
         except Exception as exc:

--- a/scraper/organizer_registry.py
+++ b/scraper/organizer_registry.py
@@ -1,0 +1,162 @@
+"""Authoritative organizer registry — deterministic organizer_type lookup.
+
+Mirrors ``venue_registry.py``'s lazy-load + module-level cache design, scoped to
+``organizers`` rows flagged ``is_authoritative = true``. Wave 2 batch-4 wires the
+annotator to consult this registry so verified entity types take precedence over
+event-topic LLM inference. LLM output must never write back into the registry.
+
+Graceful degradation
+--------------------
+The ``is_authoritative`` column ships in migration 095. On any database where
+095 has not been applied yet (e.g. the daily CI run that fires before the
+migration lands) the load query fails on the missing column. Instead of crashing
+the annotation pipeline we log at ``debug`` level and return an **empty registry**
+— every lookup returns ``None``, a silent no-op. This mirrors
+``database._populate_entity_fks``'s migration-050 backwards-compat pattern
+(``except Exception: logger.debug(...)``): never raise.
+
+Duplicate fail-closed
+---------------------
+If the same canonical name (canonical-vs-canonical) or the same alias
+(alias-vs-alias) maps to more than one authoritative entity, the key is
+ambiguous. It is added to a reject set and logged at ``error`` level; every
+lookup for that key returns ``None`` rather than picking an arbitrary row.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+_THIS_DIR = Path(__file__).resolve().parent
+if str(_THIS_DIR) not in sys.path:
+    sys.path.append(str(_THIS_DIR))
+
+from database import _get_client
+
+logger = logging.getLogger(__name__)
+
+# Module-level lazy singletons (mirror venue_registry._CACHE). ``_CANONICAL`` is
+# both the canonical_name_ja map and the loaded-sentinel: ``None`` means "not yet
+# built". ``_ALIASES`` maps alias -> entity. ``_REJECTED`` holds ambiguous keys
+# that fail closed. After a graceful load failure all three are set to empty
+# containers (not None), so the failing query is not retried on every lookup.
+_CANONICAL: dict[str, dict[str, Any]] | None = None
+_ALIASES: dict[str, dict[str, Any]] = {}
+_REJECTED: set[str] = set()
+
+
+def _register(dest: dict[str, dict[str, Any]], rejected: set[str], key: str, row: dict[str, Any]) -> None:
+    """Insert ``key -> row`` into ``dest``, flagging same-tier duplicates.
+
+    If ``key`` already maps to a *different* authoritative entity within the same
+    tier, the key is ambiguous: record it in ``rejected`` (logging once) and do
+    not overwrite. Rejected keys are purged from every map after the build.
+    """
+    existing = dest.get(key)
+    if existing is not None and existing.get("id") != row.get("id"):
+        if key not in rejected:
+            logger.error(
+                "organizer_registry: key %r maps to multiple authoritative organizers "
+                "(%s, %s); rejecting key (lookup will return None).",
+                key,
+                existing.get("id"),
+                row.get("id"),
+            )
+        rejected.add(key)
+        return
+    dest[key] = row
+
+
+def _build_cache() -> None:
+    global _CANONICAL, _ALIASES, _REJECTED
+
+    sb = _get_client()
+    try:
+        rows = (
+            sb.table("organizers")
+            .select("id,canonical_name_ja,aliases,organizer_type")
+            .eq("is_authoritative", True)
+            .execute()
+            .data
+            or []
+        )
+    except Exception as exc:
+        # is_authoritative ships in migration 095. Before it is applied the
+        # column does not exist and this query raises. Fail closed to an empty
+        # registry — never raise, so the annotation pipeline keeps running.
+        logger.debug(
+            "organizer_registry: authoritative load failed "
+            "(organizers.is_authoritative may not be migrated yet); "
+            "returning empty registry. error=%s",
+            exc,
+        )
+        _CANONICAL, _ALIASES, _REJECTED = {}, {}, set()
+        return
+
+    canonical: dict[str, dict[str, Any]] = {}
+    aliases: dict[str, dict[str, Any]] = {}
+    rejected: set[str] = set()
+
+    for row in rows:
+        canonical_name = (row.get("canonical_name_ja") or "").strip()
+        if canonical_name:
+            _register(canonical, rejected, canonical_name, row)
+        for alias in row.get("aliases") or []:
+            key = (alias or "").strip()
+            if key:
+                _register(aliases, rejected, key, row)
+
+    # Purge every rejected key from both tiers so a later same-entity duplicate
+    # cannot resurrect an ambiguous key.
+    for key in rejected:
+        canonical.pop(key, None)
+        aliases.pop(key, None)
+
+    _CANONICAL, _ALIASES, _REJECTED = canonical, aliases, rejected
+    logger.info(
+        "organizer_registry loaded: %d authoritative organizers, "
+        "%d canonical keys, %d alias keys, %d rejected",
+        len(rows),
+        len(canonical),
+        len(aliases),
+        len(rejected),
+    )
+
+
+def lookup_organizer(name: str | None) -> dict[str, Any] | None:
+    """Return the authoritative organizer entity for ``name``, or ``None``.
+
+    Resolution order: canonical_name_ja exact match first, then alias exact
+    match. A key that maps to multiple authoritative entities (duplicate
+    canonical or duplicate alias) is in the reject set and returns ``None``
+    (fail closed). Unknown names and an empty/unmigrated registry return
+    ``None``.
+    """
+    global _CANONICAL
+    if _CANONICAL is None:
+        _build_cache()
+    if not name:
+        return None
+    key = name.strip()
+    if not key:
+        return None
+    if key in _REJECTED:
+        return None
+    hit = _CANONICAL.get(key) if _CANONICAL else None
+    if hit is not None:
+        return hit
+    return _ALIASES.get(key)
+
+
+def reset_cache() -> None:
+    """Reset the module-level cache so the next lookup rebuilds it.
+
+    Test aid — production code loads once per process.
+    """
+    global _CANONICAL, _ALIASES, _REJECTED
+    _CANONICAL = None
+    _ALIASES = {}
+    _REJECTED = set()

--- a/scraper/seed_authoritative_organizers.py
+++ b/scraper/seed_authoritative_organizers.py
@@ -1,0 +1,444 @@
+#!/usr/bin/env python3
+"""Seed authoritative organizers — Wave 2 Phase D (reviewed seed, dry-run first).
+
+Seeds the first batch of *high-confidence, unambiguous* commercial-brand
+organizers (chain bookstores / retail) into ``organizers`` with
+``is_authoritative = true`` so the registry resolver (batch-4
+``annotator._apply_organizer_registry``) can override event-topic LLM inference.
+
+⛔ SCOPE — this batch is CODE-ONLY: the default mode is ``--dry-run`` and NO
+row is ever written unless ``--apply`` is passed AND migration 095 has been
+applied. The real seed is production gate 2C; do NOT run ``--apply`` here.
+
+Graceful degradation (migration 095 not yet applied)
+----------------------------------------------------
+``organizers.is_authoritative`` ships in migration 095. Before it is applied
+the schema-compatibility pre-flight detects the missing column and the dry-run
+still shows the full seed plan, flagging every entry ``需先 apply 095``. The
+``--apply`` path refuses to run until the column exists (fail closed).
+
+Pre-flight (always runs in dry-run)
+-----------------------------------
+1. canonical/alias collision — the same key mapping to >1 canonical entity
+   inside the seed list is rejected (fail closed; never seed an ambiguous key).
+2. existing type conflict — an ``organizers`` row already carrying a *different*
+   non-null ``organizer_type`` is flagged and the entry is rejected for apply.
+3. evidence missing — an entry with neither ``homepage`` nor ``notes`` is
+   flagged (authoritative rows should carry provenance).
+4. schema compatibility — ``is_authoritative`` presence (see above).
+
+The seed list is intentionally extensible: ``--manifest`` may point at a
+batch-1 ``audit_organizers.py`` JSON manifest to surface additional A1
+(department / mall / bookstore / retail) candidates *for human review only*.
+Candidates are printed, never auto-seeded — the final list is confirmed by a
+human at gate 2C.
+
+Usage::
+
+    python seed_authoritative_organizers.py                 # dry-run (default)
+    python seed_authoritative_organizers.py --manifest /tmp/organizer_audit_*.json
+    python seed_authoritative_organizers.py --apply         # gate 2C ONLY
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+from collections import defaultdict
+from typing import Any
+
+from dotenv import load_dotenv
+
+from database import _get_client
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+# Canonical storage vocabulary (10 values) — mirrors migration 095 CHECK.
+CANONICAL_TYPES = frozenset([
+    "government", "semi_official", "cultural_institution", "academic",
+    "commercial_brand", "independent_venue", "civic_group", "media",
+    "individual", "unknown",
+])
+
+# --------------------------------------------------------------------------- #
+# Core high-confidence seed list (batch-5).                                    #
+# Chain bookstores / retail brands whose legal-operating identity is           #
+# unambiguously ``commercial_brand``. Branch-name spellings surfaced by the    #
+# batch-1 audit are recorded as aliases so per-branch event rows resolve to    #
+# the one canonical entity.                                                    #
+# --------------------------------------------------------------------------- #
+SEED_DATA: list[dict[str, Any]] = [
+    {
+        "canonical_name_ja": "紀伊國屋書店",
+        "canonical_name_zh": "紀伊國屋書店",
+        "canonical_name_en": "Kinokuniya",
+        "organizer_type": "commercial_brand",
+        "is_authoritative": True,
+        "aliases": ["紀伊国屋書店", "KINOKUNIYA", "Books Kinokuniya"],
+        "homepage": "https://www.kinokuniya.co.jp/",
+        "notes": "連鎖書店（株式会社紀伊國屋書店）— 營利零售，legal identity commercial_brand。",
+    },
+    {
+        "canonical_name_ja": "誠品書店",
+        "canonical_name_zh": "誠品書店",
+        "canonical_name_en": "Eslite Bookstore",
+        "organizer_type": "commercial_brand",
+        "is_authoritative": True,
+        "aliases": ["誠品", "eslite", "Eslite"],
+        "homepage": "https://www.eslite.com/",
+        "notes": "連鎖書店／零售品牌（誠品）— commercial_brand。誠品生活日本橋為分店（venue 已 seed）。",
+    },
+    {
+        "canonical_name_ja": "株式会社有隣堂",
+        "canonical_name_zh": "有隣堂",
+        "canonical_name_en": "Yurindo Co., Ltd.",
+        "organizer_type": "commercial_brand",
+        "is_authoritative": True,
+        "aliases": ["有隣堂", "有鄰堂", "YURINDO"],
+        "homepage": "https://www.yurindo.co.jp/",
+        "notes": (
+            "連鎖書店（株式会社有隣堂）— commercial_brand。Wave 1 已於 event 層"
+            "（eslite_spectrum / 50c83c11）以 FC 鎖定 commercial_brand，此處建立 entity authority。"
+        ),
+    },
+    {
+        "canonical_name_ja": "蔦屋書店",
+        "canonical_name_zh": "蔦屋書店",
+        "canonical_name_en": "TSUTAYA BOOKS",
+        "organizer_type": "commercial_brand",
+        "is_authoritative": True,
+        "aliases": [
+            "TSUTAYA", "TSUTAYA BOOKS",
+            "代官山 蔦屋書店", "代官山蔦屋書店",
+            "奈良 蔦屋書店", "奈良蔦屋書店",
+            "京都 蔦屋書店", "京都蔦屋書店",
+            "梅田 蔦屋書店", "梅田蔦屋書店",
+            "すみだ 蔦屋書店", "すみだ蔦屋書店",
+        ],
+        "notes": (
+            "連鎖書店／零售品牌（蔦屋書店 / CCC）— commercial_brand。Wave 1 已修正"
+            "『奈良 蔦屋書店』event 由 cultural_institution → commercial_brand，此處建立 entity authority。"
+        ),
+        "homepage": "https://store.tsite.jp/",
+    },
+]
+
+# Audit-manifest cohorts / keyword signals that suggest a chain-retail entity
+# worth human review for a future seed batch (never auto-seeded).
+_CANDIDATE_COHORTS = frozenset(["A1"])
+_CANDIDATE_KEYWORD_SIGNALS = frozenset(["dept", "mall", "bookstore", "retail"])
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers (no DB) — directly unit-testable.                               #
+# --------------------------------------------------------------------------- #
+def _keys_of(entry: dict[str, Any]) -> list[str]:
+    """Canonical + aliases, trimmed, non-empty."""
+    raw = [entry.get("canonical_name_ja")] + list(entry.get("aliases") or [])
+    return [(k or "").strip() for k in raw if (k or "").strip()]
+
+
+def check_alias_collisions(entries: list[dict[str, Any]]) -> dict[str, list[str]]:
+    """Return ``{key: [canonicals…]}`` for every key mapping to >1 canonical.
+
+    A canonical name or alias that resolves to two different seed entities is
+    ambiguous; the registry would fail closed on it, so it must never be seeded.
+    """
+    key_to_canons: dict[str, set[str]] = defaultdict(set)
+    for entry in entries:
+        canonical = (entry.get("canonical_name_ja") or "").strip()
+        if not canonical:
+            continue
+        for key in _keys_of(entry):
+            key_to_canons[key].add(canonical)
+    return {k: sorted(c) for k, c in key_to_canons.items() if len(c) > 1}
+
+
+def _merge_aliases(existing: list[str] | None, incoming: list[str] | None, canonical: str) -> list[str]:
+    merged = {(a or "").strip() for a in (existing or []) + (incoming or []) if (a or "").strip()}
+    merged.discard(canonical)
+    return sorted(merged)
+
+
+def validate_seed_types(entries: list[dict[str, Any]]) -> list[str]:
+    """Return canonical names whose seed ``organizer_type`` is not canonical.
+
+    Guards against a typo in ``SEED_DATA`` writing an illegal type that
+    migration 095's CHECK would later reject.
+    """
+    bad = []
+    for entry in entries:
+        t = entry.get("organizer_type")
+        if not (isinstance(t, str) and t in CANONICAL_TYPES):
+            bad.append(entry.get("canonical_name_ja") or "<unnamed>")
+    return bad
+
+
+# --------------------------------------------------------------------------- #
+# DB-touching helpers (read-only in dry-run).                                  #
+# --------------------------------------------------------------------------- #
+def check_schema_ready(sb: Any) -> bool:
+    """True when ``organizers.is_authoritative`` exists (migration 095 applied).
+
+    Graceful: on the pre-095 schema the column is missing and the probe query
+    raises; we log at debug and return False so dry-run can flag it.
+    """
+    try:
+        sb.table("organizers").select("id,is_authoritative").limit(1).execute()
+        return True
+    except Exception as exc:
+        logger.debug(
+            "organizers.is_authoritative absent (migration 095 not applied): %s", exc
+        )
+        return False
+
+
+def fetch_existing_organizer(sb: Any, canonical: str) -> dict[str, Any] | None:
+    """Return the existing ``organizers`` row for ``canonical`` (or None).
+
+    Selects only pre-095 columns so the probe works on any schema version.
+    """
+    try:
+        rows = (
+            sb.table("organizers")
+            .select("id,canonical_name_ja,aliases,organizer_type")
+            .eq("canonical_name_ja", canonical)
+            .limit(1)
+            .execute()
+            .data
+            or []
+        )
+        return rows[0] if rows else None
+    except Exception as exc:
+        logger.debug("existing organizer lookup failed for %r: %s", canonical, exc)
+        return None
+
+
+def evaluate_entry(
+    sb: Any, entry: dict[str, Any], collision_keys: set[str]
+) -> dict[str, Any]:
+    """Run per-entry pre-flight and compute the before/after seed plan.
+
+    ``rejected`` is True when the entry has an alias collision or an existing
+    type conflict — those must not be seeded (fail closed). ``evidence_missing``
+    is advisory (flagged, not rejected).
+    """
+    canonical = entry["canonical_name_ja"]
+    seed_type = entry["organizer_type"]
+    existing = fetch_existing_organizer(sb, canonical)
+
+    existing_type = existing.get("organizer_type") if existing else None
+    type_conflict = (
+        existing_type
+        if (existing_type and existing_type != seed_type)
+        else None
+    )
+    evidence_missing = not (entry.get("homepage") or entry.get("notes"))
+    collides = sorted(k for k in _keys_of(entry) if k in collision_keys)
+
+    merged_aliases = _merge_aliases(
+        existing.get("aliases") if existing else None,
+        entry.get("aliases"),
+        canonical,
+    )
+
+    before = {
+        "exists": bool(existing),
+        "organizer_type": existing_type,
+        "aliases": list(existing.get("aliases") or []) if existing else None,
+        # is_authoritative deliberately not selected (absent pre-095).
+    }
+    after = {
+        "organizer_type": seed_type,
+        "is_authoritative": True,
+        "aliases": merged_aliases,
+    }
+    return {
+        "canonical": canonical,
+        "action": "update" if existing else "insert",
+        "before": before,
+        "after": after,
+        "type_conflict": type_conflict,
+        "evidence_missing": evidence_missing,
+        "collisions": collides,
+        "rejected": bool(collides) or bool(type_conflict),
+    }
+
+
+def build_payload(entry: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]:
+    """Construct the upsert payload (apply path only)."""
+    payload: dict[str, Any] = {
+        "canonical_name_ja": entry["canonical_name_ja"],
+        "canonical_name_zh": entry.get("canonical_name_zh"),
+        "canonical_name_en": entry.get("canonical_name_en"),
+        "organizer_type": entry["organizer_type"],
+        "is_authoritative": True,
+        "aliases": plan["after"]["aliases"],
+    }
+    if entry.get("homepage"):
+        payload["homepage"] = entry["homepage"]
+    if entry.get("notes"):
+        payload["notes"] = entry["notes"]
+    return payload
+
+
+# --------------------------------------------------------------------------- #
+# Optional audit-manifest candidate discovery (human review only).            #
+# --------------------------------------------------------------------------- #
+def load_manifest_candidates(manifest_path: str) -> list[dict[str, Any]]:
+    """Return A1 / chain-retail candidate entities from an audit JSON manifest.
+
+    These are suggestions for a human to confirm at gate 2C — never auto-seeded.
+    """
+    with open(manifest_path, encoding="utf-8") as fh:
+        manifest = json.load(fh)
+    seeded_keys = {k for e in SEED_DATA for k in _keys_of(e)}
+    candidates: list[dict[str, Any]] = []
+    for ent in manifest.get("entities") or []:
+        cohorts = set(ent.get("cohorts") or [])
+        kw = set((ent.get("keyword_signals") or {}).keys())
+        if not (cohorts & _CANDIDATE_COHORTS or kw & _CANDIDATE_KEYWORD_SIGNALS):
+            continue
+        canonical = ent.get("canonical")
+        if canonical in seeded_keys:
+            continue  # already covered by the core list
+        candidates.append({
+            "canonical": canonical,
+            "aliases": ent.get("aliases") or [],
+            "distinct_meaningful_types": ent.get("distinct_meaningful_types") or [],
+            "cohorts": sorted(cohorts),
+            "keyword_signals": sorted(kw),
+            "event_count": ent.get("event_count"),
+        })
+    return candidates
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration.                                                               #
+# --------------------------------------------------------------------------- #
+def run(dry_run: bool = True, manifest_path: str | None = None) -> dict[str, Any]:
+    sb = _get_client()
+
+    bad_types = validate_seed_types(SEED_DATA)
+    if bad_types:
+        raise SystemExit(f"[ERROR] seed entries carry non-canonical organizer_type: {bad_types}")
+
+    collisions = check_alias_collisions(SEED_DATA)
+    collision_keys = set(collisions)
+    schema_ready = check_schema_ready(sb)
+    plans = [evaluate_entry(sb, e, collision_keys) for e in SEED_DATA]
+
+    mode = "DRY-RUN" if dry_run else "APPLY"
+    print(f"=== seed_authoritative_organizers [{mode}] — {len(SEED_DATA)} core entries ===")
+    if not schema_ready:
+        print("[SCHEMA] organizers.is_authoritative 不存在 → 需先 apply migration 095（gate 2B）。")
+        print("[SCHEMA] dry-run 仍顯示完整 seed 計畫；--apply 會被拒絕直到 095 落地。")
+    else:
+        print("[SCHEMA] organizers.is_authoritative 就緒（migration 095 已套用）。")
+
+    if collisions:
+        print(f"[PRE-FLIGHT collision] {len(collisions)} 個 key 對映多 canonical（fail closed）：")
+        for key, canons in sorted(collisions.items()):
+            print(f"    - {key!r} → {canons}")
+    else:
+        print("[PRE-FLIGHT collision] 無 canonical/alias collision。")
+
+    seedable = 0
+    for plan in plans:
+        flags = []
+        if plan["collisions"]:
+            flags.append(f"collision={plan['collisions']}")
+        if plan["type_conflict"]:
+            flags.append(f"type_conflict(existing={plan['type_conflict']})")
+        if plan["evidence_missing"]:
+            flags.append("evidence_missing")
+        if not schema_ready:
+            flags.append("需先 apply 095")
+        status = "REJECT" if plan["rejected"] else "OK"
+        if not plan["rejected"]:
+            seedable += 1
+        before = plan["before"]
+        after = plan["after"]
+        before_desc = (
+            f"exists type={before['organizer_type']} aliases={len(before['aliases'] or [])}"
+            if before["exists"] else "not present"
+        )
+        print(
+            f"[{status} {plan['action']}] {plan['canonical']}\n"
+            f"    before: {before_desc}\n"
+            f"    after : type={after['organizer_type']} is_authoritative=True "
+            f"aliases={len(after['aliases'])}"
+            + (f"\n    flags : {', '.join(flags)}" if flags else "")
+        )
+
+    if manifest_path:
+        try:
+            candidates = load_manifest_candidates(manifest_path)
+        except Exception as exc:
+            print(f"[MANIFEST] 讀取失敗 {manifest_path}: {exc}")
+            candidates = []
+        print(f"\n[MANIFEST] {len(candidates)} 個 A1／零售候選（人工確認 gate 2C，非本批 seed）：")
+        for c in candidates[:30]:
+            print(
+                f"    - {c['canonical']} events={c['event_count']} "
+                f"types={c['distinct_meaningful_types']} cohorts={c['cohorts']} "
+                f"kw={c['keyword_signals']}"
+            )
+
+    print(
+        f"\n[{mode}] summary | core={len(SEED_DATA)} seedable={seedable} "
+        f"rejected={len(SEED_DATA) - seedable} schema_ready={schema_ready}"
+    )
+
+    applied = 0
+    if not dry_run:
+        if not schema_ready:
+            raise SystemExit(
+                "[ERROR] 拒絕 apply：organizers.is_authoritative 不存在，請先套用 migration 095（gate 2B）。"
+            )
+        for entry, plan in zip(SEED_DATA, plans):
+            if plan["rejected"]:
+                print(f"[SKIP apply] {plan['canonical']} (pre-flight rejected)")
+                continue
+            payload = build_payload(entry, plan)
+            sb.table("organizers").upsert(payload, on_conflict="canonical_name_ja").execute()
+            applied += 1
+            print(f"[APPLY {plan['action']}] {plan['canonical']}")
+        print(f"[APPLY] wrote {applied} authoritative organizer row(s).")
+
+    return {
+        "core": len(SEED_DATA),
+        "seedable": seedable,
+        "rejected": len(SEED_DATA) - seedable,
+        "schema_ready": schema_ready,
+        "collisions": collisions,
+        "plans": plans,
+        "applied": applied,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Seed authoritative organizers with conflict-safe pre-flight (dry-run default)."
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Write authoritative rows (gate 2C ONLY; refused until migration 095 is applied).",
+    )
+    parser.add_argument(
+        "--manifest",
+        default=None,
+        help="Optional audit_organizers.py JSON manifest for A1/retail candidate suggestions.",
+    )
+    args = parser.parse_args()
+
+    load_dotenv(os.path.join(os.path.dirname(__file__), ".env"))
+    run(dry_run=not args.apply, manifest_path=args.manifest)
+
+
+if __name__ == "__main__":
+    main()

--- a/scraper/tests/test_annotator_registry_precedence.py
+++ b/scraper/tests/test_annotator_registry_precedence.py
@@ -1,0 +1,175 @@
+"""Registry-precedence tests for ``annotator._apply_organizer_registry``.
+
+Every test monkeypatches ``annotator.lookup_organizer`` with a controlled fake,
+so none of them depend on a live database or on migration 095's
+``organizers.is_authoritative`` column. The final test pins the graceful-
+degradation contract: when the registry is empty (every lookup → ``None``, the
+real behaviour before migration 095 is applied) the helper is a field-for-field
+no-op, even for GPT payloads whose parallel arrays have mismatched cardinality.
+"""
+
+import copy
+
+import annotator
+
+
+def _entity(organizer_type: str, name: str = "X") -> dict:
+    return {
+        "id": f"id-{name}-{organizer_type}",
+        "canonical_name_ja": name,
+        "aliases": [],
+        "organizer_type": organizer_type,
+    }
+
+
+def _patch_lookup(monkeypatch, mapping: dict) -> None:
+    """Patch annotator.lookup_organizer. mapping: {name: type}; misses → None."""
+
+    def fake(name):
+        if not name:
+            return None
+        t = mapping.get(name)
+        return _entity(t, name) if t else None
+
+    monkeypatch.setattr(annotator, "lookup_organizer", fake)
+
+
+# --------------------------------------------------------------------------- #
+# Primary organizer_type — scalar registry value → events.organizer_type[]     #
+# --------------------------------------------------------------------------- #
+
+def test_primary_case_a_empty_or_unknown_adopts_registry(monkeypatch):
+    _patch_lookup(monkeypatch, {"誠品生活日本橋": "commercial_brand"})
+    for current in (None, [], ["unknown"], ["unknown", "unknown"]):
+        data = {"organizer": "誠品生活日本橋", "organizer_type": current}
+        annotator._apply_organizer_registry({}, data)
+        assert data["organizer_type"] == ["commercial_brand"]
+
+
+def test_primary_case_b_already_contains_registry_preserved(monkeypatch):
+    _patch_lookup(monkeypatch, {"某大学": "academic"})
+    data = {"organizer": "某大学", "organizer_type": ["academic", "media"]}
+    annotator._apply_organizer_registry({}, data)
+    # Existing legal multi-type array containing the registry type is preserved
+    # verbatim — no flatten, no reorder.
+    assert data["organizer_type"] == ["academic", "media"]
+
+
+def test_primary_case_c_single_conflict_registry_wins(monkeypatch):
+    _patch_lookup(monkeypatch, {"有隣堂": "commercial_brand"})
+    data = {"organizer": "有隣堂", "organizer_type": ["independent_venue"]}
+    annotator._apply_organizer_registry({}, data)
+    assert data["organizer_type"] == ["commercial_brand"]
+
+
+def test_primary_case_d_multi_conflict_fail_closed(monkeypatch):
+    _patch_lookup(monkeypatch, {"某団体": "government"})
+    data = {"organizer": "某団体", "organizer_type": ["academic", "media"]}
+    annotator._apply_organizer_registry({}, data)
+    # >=2 legal types, none is the registry type → fail closed: keep the original
+    # array untouched (no auto-flatten to the single scalar registry value).
+    assert data["organizer_type"] == ["academic", "media"]
+
+
+# --------------------------------------------------------------------------- #
+# Co-organizer / Sponsor parallel arrays — per-index overlay, cardinality lock  #
+# --------------------------------------------------------------------------- #
+
+def test_co_hit_overrides_same_index_and_miss_preserves(monkeypatch):
+    _patch_lookup(monkeypatch, {"紀伊國屋書店": "commercial_brand"})
+    data = {
+        "co_organizers": ["紀伊國屋書店", "地元の会"],
+        "co_organizer_types": ["cultural_institution", "civic_group"],
+    }
+    annotator._apply_organizer_registry({}, data)
+    # index0 registry hit overrides; index1 miss keeps existing legal value.
+    assert data["co_organizer_types"] == ["commercial_brand", "civic_group"]
+
+
+def test_sponsor_cardinality_maintained_when_types_shorter(monkeypatch):
+    _patch_lookup(monkeypatch, {"A社": "commercial_brand"})
+    data = {
+        "sponsors": ["A社", "B団体", "C機構"],
+        "sponsor_types": [],  # GPT returned mismatched (empty) types
+    }
+    annotator._apply_organizer_registry({}, data)
+    assert data["sponsor_types"] == ["commercial_brand", "unknown", "unknown"]
+    assert len(data["sponsor_types"]) == len(data["sponsors"])
+
+
+def test_co_miss_preserves_valid_and_normalizes_invalid(monkeypatch):
+    _patch_lookup(monkeypatch, {"A社": "commercial_brand"})
+    data = {
+        "co_organizers": ["A社", "既知団体", "不明"],
+        "co_organizer_types": ["unknown", "civic_group", "bogus_value"],
+    }
+    annotator._apply_organizer_registry({}, data)
+    # index0 hit; index1 miss keeps civic_group; index2 miss + invalid → unknown.
+    assert data["co_organizer_types"] == ["commercial_brand", "civic_group", "unknown"]
+
+
+# --------------------------------------------------------------------------- #
+# Precedence: FC > registry, registry > existing unknown, raw names untouched   #
+# --------------------------------------------------------------------------- #
+
+def test_fc_protected_primary_type_not_touched(monkeypatch):
+    _patch_lookup(monkeypatch, {"有隣堂": "commercial_brand"})
+    data = {"organizer": "有隣堂", "organizer_type": ["independent_venue"]}
+    # organizer_type is FC-locked → registry must skip it (FC restore wins later).
+    annotator._apply_organizer_registry({}, data, {"organizer_type": '["independent_venue"]'})
+    assert data["organizer_type"] == ["independent_venue"]
+
+
+def test_fc_protected_co_types_not_touched(monkeypatch):
+    _patch_lookup(monkeypatch, {"紀伊國屋書店": "commercial_brand"})
+    data = {
+        "co_organizers": ["紀伊國屋書店"],
+        "co_organizer_types": ["cultural_institution"],
+    }
+    annotator._apply_organizer_registry({}, data, {"co_organizer_types": "x"})
+    assert data["co_organizer_types"] == ["cultural_institution"]
+
+
+def test_registry_never_overwrites_raw_name_text(monkeypatch):
+    _patch_lookup(monkeypatch, {
+        "有隣堂": "commercial_brand",
+        "紀伊國屋書店": "commercial_brand",
+        "A社": "government",
+    })
+    data = {
+        "organizer": "有隣堂",
+        "organizer_type": ["unknown"],
+        "co_organizers": ["紀伊國屋書店"],
+        "co_organizer_types": ["cultural_institution"],
+        "sponsors": ["A社"],
+        "sponsor_types": ["unknown"],
+    }
+    annotator._apply_organizer_registry({}, data)
+    # Types are refined, but the raw name strings are never rewritten.
+    assert data["organizer"] == "有隣堂"
+    assert data["co_organizers"] == ["紀伊國屋書店"]
+    assert data["sponsors"] == ["A社"]
+    assert data["organizer_type"] == ["commercial_brand"]
+    assert data["co_organizer_types"] == ["commercial_brand"]
+    assert data["sponsor_types"] == ["government"]
+
+
+# --------------------------------------------------------------------------- #
+# Graceful equivalence — empty/unmigrated registry is a byte-for-byte no-op     #
+# --------------------------------------------------------------------------- #
+
+def test_graceful_noop_when_registry_empty(monkeypatch):
+    monkeypatch.setattr(annotator, "lookup_organizer", lambda name: None)
+    data = {
+        "organizer": "誠品生活日本橋",
+        "organizer_type": ["independent_venue"],
+        "co_organizers": ["紀伊國屋書店", "地元の会"],
+        # Deliberately mismatched cardinality (2 names, 1 type): the empty
+        # registry must NOT "fix" it — that is A.5 / migration-095's job.
+        "co_organizer_types": ["cultural_institution"],
+        "sponsors": ["A社"],
+        "sponsor_types": [],
+    }
+    before = copy.deepcopy(data)
+    annotator._apply_organizer_registry({}, data)
+    assert data == before

--- a/scraper/tests/test_backfill_organizer_authority.py
+++ b/scraper/tests/test_backfill_organizer_authority.py
@@ -1,0 +1,262 @@
+"""Unit tests for ``backfill_organizer_authority`` (Wave 2 Phase D backfill).
+
+The backfill delegates its type-mutation logic to
+``annotator._apply_organizer_registry`` (single source of truth), so these
+tests verify the *wiring*: field copy, four-case outcome flow-through,
+organizer_id FK resolution, FC-skip accounting, and that the dry-run never
+writes. The registry is faked (no DB, no migration 095 needed) by patching
+``lookup_organizer`` in BOTH the annotator and backfill modules.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+import annotator
+import backfill_organizer_authority as backfill
+
+
+# --------------------------------------------------------------------------- #
+# Fake registry — patched into both modules so the primary type overlay        #
+# (annotator) and the organizer_id FK (backfill) see the same entities.        #
+# --------------------------------------------------------------------------- #
+def _entity(name, org_type, ent_id=None):
+    return {
+        "id": ent_id or f"org-{name}",
+        "canonical_name_ja": name,
+        "aliases": [],
+        "organizer_type": org_type,
+    }
+
+
+@pytest.fixture
+def fake_registry(monkeypatch):
+    """Install a name→entity map into both annotator and backfill lookups."""
+    def _install(mapping):
+        def _lookup(name):
+            return mapping.get(name) if name else None
+        monkeypatch.setattr(annotator, "lookup_organizer", _lookup)
+        monkeypatch.setattr(backfill, "lookup_organizer", _lookup)
+    return _install
+
+
+# --------------------------------------------------------------------------- #
+# Primary organizer_type — four cases (outcome flows through plan_event)        #
+# --------------------------------------------------------------------------- #
+def test_primary_case_a_empty_adopts_registry(fake_registry):
+    fake_registry({"有隣堂": _entity("有隣堂", "commercial_brand", "org-y")})
+    event = {"id": "e1", "organizer": "有隣堂", "organizer_type": ["unknown"],
+             "organizer_id": "org-y"}
+    p = backfill.plan_event(event, set())
+    assert p["after"]["organizer_type"] == ["commercial_brand"]
+    assert p["changed"] is True
+
+
+def test_primary_case_b_already_contains_preserved(fake_registry):
+    fake_registry({"某大学": _entity("某大学", "academic", "org-u")})
+    event = {"id": "e2", "organizer": "某大学",
+             "organizer_type": ["academic", "media"], "organizer_id": "org-u"}
+    p = backfill.plan_event(event, set())
+    # Preserved verbatim (no flatten / reorder), no org_id change.
+    assert p["after"]["organizer_type"] == ["academic", "media"]
+    assert p["org_id_change"] is None
+    assert p["changed"] is False
+
+
+def test_primary_case_c_single_conflict_registry_wins(fake_registry):
+    fake_registry({"誠品書店": _entity("誠品書店", "commercial_brand", "org-e")})
+    event = {"id": "e3", "organizer": "誠品書店",
+             "organizer_type": ["independent_venue"], "organizer_id": "org-e"}
+    p = backfill.plan_event(event, set())
+    assert p["after"]["organizer_type"] == ["commercial_brand"]
+    assert p["primary_conflict"] is False
+
+
+def test_primary_case_d_multi_conflict_fail_closed(fake_registry):
+    fake_registry({"複合団体": _entity("複合団体", "government", "org-g")})
+    event = {"id": "e4", "organizer": "複合団体",
+             "organizer_type": ["academic", "media"], "organizer_id": "org-g"}
+    p = backfill.plan_event(event, set())
+    # Fail closed: original multi-type array preserved, flagged for manual queue.
+    assert p["after"]["organizer_type"] == ["academic", "media"]
+    assert p["primary_conflict"] is True
+    assert p["changed"] is False
+
+
+# --------------------------------------------------------------------------- #
+# Co-organizer / sponsor cardinality parity                                    #
+# --------------------------------------------------------------------------- #
+def test_sponsor_cardinality_parity(fake_registry):
+    fake_registry({"A社": _entity("A社", "commercial_brand", "org-a")})
+    event = {
+        "id": "e5", "organizer": None, "organizer_id": None,
+        "sponsors": ["A社", "B社", "C社"], "sponsor_types": [],
+    }
+    p = backfill.plan_event(event, set())
+    after = p["after"]["sponsor_types"]
+    assert len(after) == 3                       # parity with sponsors
+    assert after[0] == "commercial_brand"        # registry-resolved index
+    assert after[1] == "unknown" and after[2] == "unknown"
+    assert p["unknowns"] == 2
+
+
+def test_co_organizer_untouched_when_no_registry_hit(fake_registry):
+    fake_registry({})  # empty registry
+    event = {
+        "id": "e6", "organizer": None, "organizer_id": None,
+        "co_organizers": ["X会", "Y会"], "co_organizer_types": ["civic_group"],
+    }
+    p = backfill.plan_event(event, set())
+    # No hit anywhere → full no-op (array left exactly as-is).
+    assert p["after"]["co_organizer_types"] == ["civic_group"]
+    assert p["changed"] is False
+
+
+# --------------------------------------------------------------------------- #
+# field_corrections protection (FC > registry)                                 #
+# --------------------------------------------------------------------------- #
+def test_fc_protected_primary_skipped_and_counted(fake_registry):
+    fake_registry({"有隣堂": _entity("有隣堂", "commercial_brand", "org-y")})
+    event = {"id": "e7", "organizer": "有隣堂",
+             "organizer_type": ["academic"], "organizer_id": "org-y"}
+    p = backfill.plan_event(event, {"organizer_type"})
+    # FC lock → primary type untouched despite the registry hit.
+    assert p["after"]["organizer_type"] == ["academic"]
+    assert "organizer_type" in p["fc_skips"]
+
+
+def test_fc_protected_organizer_id_not_set(fake_registry):
+    fake_registry({"有隣堂": _entity("有隣堂", "commercial_brand", "org-y")})
+    event = {"id": "e8", "organizer": "有隣堂",
+             "organizer_type": ["commercial_brand"], "organizer_id": None}
+    p = backfill.plan_event(event, {"organizer_id"})
+    # organizer_id is FC-locked → no FK write even though the primary resolves.
+    assert p["org_id_change"] is None
+    assert "organizer_id" in p["fc_skips"]
+
+
+# --------------------------------------------------------------------------- #
+# organizer_id FK resolution                                                   #
+# --------------------------------------------------------------------------- #
+def test_organizer_id_set_when_registry_hit(fake_registry):
+    fake_registry({"有隣堂": _entity("有隣堂", "commercial_brand", "org-yurindo")})
+    event = {"id": "e9", "organizer": "有隣堂",
+             "organizer_type": ["commercial_brand"], "organizer_id": None}
+    p = backfill.plan_event(event, set())
+    assert p["org_id_change"] == (None, "org-yurindo")
+    assert p["_write"].get("organizer_id") == "org-yurindo"
+    assert p["changed"] is True
+
+
+def test_registry_empty_is_noop(fake_registry):
+    fake_registry({})  # pre-095 empty registry
+    event = {"id": "e10", "organizer": "有隣堂",
+             "organizer_type": ["cultural_institution"], "organizer_id": "org-x",
+             "co_organizers": ["Z会"], "co_organizer_types": ["civic_group"]}
+    p = backfill.plan_event(event, set())
+    assert p["changed"] is False
+    assert p["registry_hit"] is False
+    assert p["before"] == p["after"]
+
+
+# --------------------------------------------------------------------------- #
+# run() dry-run must never write                                               #
+# --------------------------------------------------------------------------- #
+class _EventsBuilder:
+    def __init__(self, client):
+        self.client = client
+        self._update = None
+        self._eq = {}
+        self._range = (0, 999)
+
+    def select(self, _cols):
+        return self
+
+    def eq(self, col, val):
+        self._eq[col] = val
+        return self
+
+    def range(self, a, b):
+        self._range = (a, b)
+        return self
+
+    def update(self, payload):
+        self._update = payload
+        return self
+
+    def execute(self):
+        if self._update is not None:
+            self.client.updates.append((self._eq.get("id"), self._update))
+            return SimpleNamespace(data=[])
+        if self._range[0] == 0:
+            return SimpleNamespace(data=[dict(e) for e in self.client.events])
+        return SimpleNamespace(data=[])
+
+
+class _FCBuilder:
+    def __init__(self, client):
+        self.client = client
+        self._range = (0, 999)
+
+    def select(self, _cols):
+        return self
+
+    def range(self, a, b):
+        self._range = (a, b)
+        return self
+
+    def execute(self):
+        if self._range[0] == 0:
+            return SimpleNamespace(data=list(self.client.fc_rows))
+        return SimpleNamespace(data=[])
+
+
+class _FakeBackfillClient:
+    def __init__(self, events, fc_rows=None):
+        self.events = events
+        self.fc_rows = fc_rows or []
+        self.updates: list = []
+
+    def table(self, name):
+        if name == "events":
+            return _EventsBuilder(self)
+        if name == "field_corrections":
+            return _FCBuilder(self)
+        raise AssertionError(name)
+
+
+def test_run_dry_run_writes_nothing(monkeypatch, fake_registry):
+    fake_registry({"有隣堂": _entity("有隣堂", "commercial_brand", "org-y")})
+    client = _FakeBackfillClient(
+        events=[
+            {"id": "e-1", "organizer": "有隣堂", "organizer_id": None,
+             "organizer_type": ["unknown"], "co_organizers": None,
+             "co_organizer_types": None, "sponsors": None, "sponsor_types": None},
+            {"id": "e-2", "organizer": "無名", "organizer_id": None,
+             "organizer_type": ["academic"], "co_organizers": None,
+             "co_organizer_types": None, "sponsors": None, "sponsor_types": None},
+        ],
+    )
+    monkeypatch.setattr(backfill, "_get_client", lambda: client)
+    result = backfill.run(dry_run=True)
+    # One event resolves and would change, but dry-run writes nothing.
+    assert result["changed"] == 1
+    assert result["registry_hits"] == 1
+    assert client.updates == []
+
+
+def test_run_dry_run_empty_registry_zero_coverage(monkeypatch, fake_registry):
+    fake_registry({})  # pre-095: registry empty → zero coverage expected
+    client = _FakeBackfillClient(
+        events=[
+            {"id": "e-1", "organizer": "有隣堂", "organizer_id": "org-x",
+             "organizer_type": ["cultural_institution"], "co_organizers": None,
+             "co_organizer_types": None, "sponsors": None, "sponsor_types": None},
+        ],
+    )
+    monkeypatch.setattr(backfill, "_get_client", lambda: client)
+    result = backfill.run(dry_run=True)
+    assert result["events"] == 1
+    assert result["changed"] == 0
+    assert result["registry_hits"] == 0
+    assert client.updates == []

--- a/scraper/tests/test_organizer_registry.py
+++ b/scraper/tests/test_organizer_registry.py
@@ -1,0 +1,259 @@
+"""Unit tests for organizer_registry + _populate_entity_fks organizer resolution.
+
+Mocks the Supabase client so nothing depends on the live ``is_authoritative``
+column (migration 095 is not applied in CI at test time).
+"""
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+import organizer_registry
+from organizer_registry import lookup_organizer
+from database import _populate_entity_fks
+
+
+# --------------------------------------------------------------------------- #
+# organizer_registry fakes                                                     #
+# --------------------------------------------------------------------------- #
+class _RegistrySelect:
+    def __init__(self, rows, error):
+        self._rows = rows
+        self._error = error
+
+    def select(self, *_):
+        return self
+
+    def eq(self, *_):
+        return self
+
+    def execute(self):
+        if self._error is not None:
+            raise self._error
+        return SimpleNamespace(data=[dict(r) for r in self._rows])
+
+
+class _RegistryClient:
+    def __init__(self, rows=None, error=None):
+        self._rows = rows or []
+        self._error = error
+
+    def table(self, name):
+        assert name == "organizers", name
+        return _RegistrySelect(self._rows, self._error)
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    organizer_registry.reset_cache()
+    yield
+    organizer_registry.reset_cache()
+
+
+def _install_registry(monkeypatch, rows=None, error=None):
+    monkeypatch.setattr(
+        organizer_registry,
+        "_get_client",
+        lambda: _RegistryClient(rows=rows, error=error),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 1. canonical exact hit                                                       #
+# --------------------------------------------------------------------------- #
+def test_canonical_exact_hit(monkeypatch):
+    _install_registry(monkeypatch, rows=[
+        {"id": "org-1", "canonical_name_ja": "誠品生活",
+         "aliases": ["誠品"], "organizer_type": "commercial_brand"},
+    ])
+    hit = lookup_organizer("誠品生活")
+    assert hit is not None
+    assert hit["id"] == "org-1"
+    assert hit["organizer_type"] == "commercial_brand"
+
+
+# --------------------------------------------------------------------------- #
+# 2. alias exact hit                                                           #
+# --------------------------------------------------------------------------- #
+def test_alias_exact_hit(monkeypatch):
+    _install_registry(monkeypatch, rows=[
+        {"id": "org-1", "canonical_name_ja": "誠品生活",
+         "aliases": ["誠品", "eslite"], "organizer_type": "commercial_brand"},
+    ])
+    hit = lookup_organizer("eslite")
+    assert hit is not None
+    assert hit["id"] == "org-1"
+    assert hit["organizer_type"] == "commercial_brand"
+
+
+# --------------------------------------------------------------------------- #
+# 3. unknown name / empty input                                                #
+# --------------------------------------------------------------------------- #
+def test_unknown_name_returns_none(monkeypatch):
+    _install_registry(monkeypatch, rows=[
+        {"id": "org-1", "canonical_name_ja": "誠品生活",
+         "aliases": ["誠品"], "organizer_type": "commercial_brand"},
+    ])
+    assert lookup_organizer("紀伊國屋書店") is None
+
+
+def test_empty_and_whitespace_name_returns_none(monkeypatch):
+    _install_registry(monkeypatch, rows=[
+        {"id": "org-1", "canonical_name_ja": "誠品生活",
+         "aliases": [], "organizer_type": "commercial_brand"},
+    ])
+    assert lookup_organizer(None) is None
+    assert lookup_organizer("") is None
+    assert lookup_organizer("   ") is None
+
+
+# --------------------------------------------------------------------------- #
+# 4. duplicate alias / duplicate canonical -> fail closed                      #
+# --------------------------------------------------------------------------- #
+def test_duplicate_alias_fail_closed(monkeypatch, caplog):
+    _install_registry(monkeypatch, rows=[
+        {"id": "org-1", "canonical_name_ja": "A社",
+         "aliases": ["共用別名"], "organizer_type": "commercial_brand"},
+        {"id": "org-2", "canonical_name_ja": "B社",
+         "aliases": ["共用別名"], "organizer_type": "civic_group"},
+    ])
+    with caplog.at_level(logging.ERROR, logger="organizer_registry"):
+        assert lookup_organizer("共用別名") is None
+    # Unambiguous canonical names still resolve deterministically.
+    assert lookup_organizer("A社")["id"] == "org-1"
+    assert lookup_organizer("B社")["id"] == "org-2"
+    assert "multiple authoritative organizers" in caplog.text
+
+
+def test_duplicate_canonical_fail_closed(monkeypatch, caplog):
+    _install_registry(monkeypatch, rows=[
+        {"id": "org-1", "canonical_name_ja": "同名社",
+         "aliases": [], "organizer_type": "commercial_brand"},
+        {"id": "org-2", "canonical_name_ja": "同名社",
+         "aliases": [], "organizer_type": "civic_group"},
+    ])
+    with caplog.at_level(logging.ERROR, logger="organizer_registry"):
+        assert lookup_organizer("同名社") is None
+    assert "multiple authoritative organizers" in caplog.text
+
+
+def test_canonical_precedence_over_alias(monkeypatch):
+    # "共用名" is org-1's canonical AND org-2's alias — canonical wins, not rejected.
+    _install_registry(monkeypatch, rows=[
+        {"id": "org-1", "canonical_name_ja": "共用名",
+         "aliases": [], "organizer_type": "commercial_brand"},
+        {"id": "org-2", "canonical_name_ja": "別名社",
+         "aliases": ["共用名"], "organizer_type": "civic_group"},
+    ])
+    hit = lookup_organizer("共用名")
+    assert hit is not None
+    assert hit["id"] == "org-1"
+
+
+# --------------------------------------------------------------------------- #
+# 5. graceful degradation: load failure -> empty registry, never raise         #
+# --------------------------------------------------------------------------- #
+def test_graceful_load_failure_returns_empty(monkeypatch, caplog):
+    _install_registry(monkeypatch, error=Exception(
+        "column organizers.is_authoritative does not exist"))
+    with caplog.at_level(logging.DEBUG, logger="organizer_registry"):
+        # Must not raise, and every lookup must return None.
+        assert lookup_organizer("誠品生活") is None
+        assert lookup_organizer("誠品") is None
+    assert "may not be migrated yet" in caplog.text
+
+
+# --------------------------------------------------------------------------- #
+# _populate_entity_fks fakes                                                    #
+# --------------------------------------------------------------------------- #
+class _OrgQuery:
+    def __init__(self, client, table):
+        self.client = client
+        self.table = table
+        self.filters = []
+
+    def select(self, _cols):
+        return self
+
+    def in_(self, field, values):
+        self.filters.append(("in", field, list(values)))
+        return self
+
+    def contains(self, field, value):
+        self.filters.append(("contains", field, list(value)))
+        return self
+
+    def eq(self, field, value):
+        self.filters.append(("eq", field, value))
+        return self
+
+    def execute(self):
+        return SimpleNamespace(data=self.client._resolve(self))
+
+
+class _OrgClient:
+    def __init__(self, organizers):
+        self._organizers = organizers
+
+    def table(self, name):
+        return _OrgQuery(self, name)
+
+    def _resolve(self, q):
+        if q.table != "organizers":
+            return []
+        for kind, field, value in q.filters:
+            if kind == "in" and field == "canonical_name_ja":
+                wanted = set(value)
+                return [dict(o) for o in self._organizers
+                        if o.get("canonical_name_ja") in wanted]
+            if kind == "contains" and field == "aliases":
+                needle = value[0]
+                return [dict(o) for o in self._organizers
+                        if needle in (o.get("aliases") or [])]
+        return []
+
+
+# --------------------------------------------------------------------------- #
+# 6. _populate_entity_fks organizer resolution                                 #
+# --------------------------------------------------------------------------- #
+def test_populate_fks_alias_single_hit_sets_id_and_keeps_raw_text():
+    client = _OrgClient([
+        {"id": "org-1", "canonical_name_ja": "誠品生活股份有限公司",
+         "aliases": ["誠品"], "homepage": None},
+    ])
+    row = {"organizer": "誠品", "source_name": "src", "source_id": "1"}
+
+    _populate_entity_fks(client, [row])
+
+    assert row["organizer_id"] == "org-1"
+    # Raw organizer text must NOT be overwritten with the canonical name.
+    assert row["organizer"] == "誠品"
+
+
+def test_populate_fks_alias_collision_fail_closed(caplog):
+    client = _OrgClient([
+        {"id": "org-1", "canonical_name_ja": "A社", "aliases": ["共用"], "homepage": None},
+        {"id": "org-2", "canonical_name_ja": "B社", "aliases": ["共用"], "homepage": None},
+    ])
+    row = {"organizer": "共用", "source_name": "src", "source_id": "1"}
+
+    with caplog.at_level(logging.WARNING, logger="database"):
+        _populate_entity_fks(client, [row])
+
+    # Ambiguous alias -> organizer_id left unset (fail closed), raw text intact.
+    assert "organizer_id" not in row
+    assert row["organizer"] == "共用"
+    assert "fail closed" in caplog.text
+
+
+def test_populate_fks_canonical_hit_preserves_raw_text():
+    client = _OrgClient([
+        {"id": "org-9", "canonical_name_ja": "誠品生活", "aliases": [], "homepage": None},
+    ])
+    row = {"organizer": "誠品生活", "source_name": "src", "source_id": "1"}
+
+    _populate_entity_fks(client, [row])
+
+    assert row["organizer_id"] == "org-9"
+    assert row["organizer"] == "誠品生活"

--- a/scraper/tests/test_organizer_storage_boundary.py
+++ b/scraper/tests/test_organizer_storage_boundary.py
@@ -1,0 +1,356 @@
+"""Wave 2 Phase B0a / B — organizer storage-enum boundary + migration 095 fixture.
+
+Deterministic, offline tests (no DB required) that lock in:
+
+  * the LLM inference vocabulary stays at 9 values and never emits 'individual'
+    or any actor-only value (B0a must NOT widen the daily GPT classifier);
+  * the canonical STORAGE vocabulary is the 10-value superset (adds
+    'individual') and the trilingual web `organizerType` labels already cover
+    exactly those 10 keys, equal across zh/en/ja (expected zero i18n diff);
+  * migration 095's legacy JSON-text -> scalar normalize is lossless for the
+    unambiguous single legal value and NULLs multi/illegal values;
+  * the events cardinality CHECK predicate has the documented COALESCE
+    fail/pass semantics;
+  * migration 095's SQL is structurally correct (validated CHECKs, scalar IN
+    for research_sources, no NOT VALID, no GRANT/REVOKE/ALTER VIEW,
+    transaction-wrapped).
+
+An OPT-IN read-only DB gate test (set TTR_RUN_DB_GATE=1) reports the live
+table-wide co/sponsor mismatch count and cross-checks two independent
+cardinality implementations, demonstrating the fail-closed gate: while the
+mismatch is > 0 the validated CHECK cannot be created; it becomes creatable
+only once Phase A.5 has driven the count to 0.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from annotator import (
+    VALID_ORGANIZER_TYPES,
+    _validate_organizer_types,
+    _validate_organizer_types_list,
+)
+
+# --- canonical vocabularies ------------------------------------------------
+
+# Authoritative storage set = live events_organizer_type_check (migration 086).
+CANONICAL_STORAGE_TYPES = frozenset({
+    "government", "semi_official", "cultural_institution", "academic",
+    "commercial_brand", "independent_venue", "civic_group", "media",
+    "individual", "unknown",
+})
+
+# LLM inference set = storage set minus the storage/registry-only 'individual'.
+LLM_INFERENCE_TYPES = CANONICAL_STORAGE_TYPES - {"individual"}
+
+# Broader actor taxonomy (web/lib/actorTypes.ts) — must never leak into the
+# organizer_type enum.
+ACTOR_ONLY_VALUES = ("traveler", "writer", "food", "art")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WEB_MESSAGES_DIR = REPO_ROOT / "web" / "messages"
+MIGRATION_095 = REPO_ROOT / "supabase" / "migrations" / "095_organizer_authority.sql"
+
+
+# ===========================================================================
+# 1. LLM inference vocabulary (B0a keeps GPT at 9 values)
+# ===========================================================================
+
+def test_llm_vocabulary_is_exactly_nine_values():
+    assert set(VALID_ORGANIZER_TYPES) == set(LLM_INFERENCE_TYPES)
+    assert len(VALID_ORGANIZER_TYPES) == 9
+
+
+def test_llm_vocabulary_rejects_individual():
+    assert "individual" not in VALID_ORGANIZER_TYPES
+
+
+def test_llm_vocabulary_rejects_actor_only_values():
+    for actor in ACTOR_ONLY_VALUES:
+        assert actor not in VALID_ORGANIZER_TYPES
+
+
+def test_llm_validators_drop_individual_and_actor_only():
+    # Primary array validator and the flat parallel-array validator both drop
+    # storage-only 'individual' and actor-only values, while keeping legal
+    # inference values.
+    assert _validate_organizer_types(["commercial_brand"]) == ["commercial_brand"]
+    assert _validate_organizer_types(["individual"]) == []
+    assert _validate_organizer_types(["traveler", "writer"]) == []
+    assert _validate_organizer_types(["academic", "individual", "media"]) == ["academic", "media"]
+
+    assert _validate_organizer_types_list(["civic_group"]) == ["civic_group"]
+    assert _validate_organizer_types_list(["individual"]) == []
+    assert _validate_organizer_types_list(["food", "art"]) == []
+
+
+def test_database_layer_vocabulary_in_sync_with_annotator():
+    import database  # lazy: avoids paying the import cost for the offline suite
+
+    assert set(database._VALID_ORGANIZER_TYPES) == set(VALID_ORGANIZER_TYPES)
+    assert "individual" not in database._VALID_ORGANIZER_TYPES
+
+
+# ===========================================================================
+# 2. Canonical storage vocabulary + trilingual web labels
+# ===========================================================================
+
+def test_canonical_storage_is_ten_value_superset_of_inference():
+    assert len(CANONICAL_STORAGE_TYPES) == 10
+    assert LLM_INFERENCE_TYPES < CANONICAL_STORAGE_TYPES  # proper subset
+    assert CANONICAL_STORAGE_TYPES - LLM_INFERENCE_TYPES == {"individual"}
+
+
+def _load_organizer_type_keys(locale: str) -> set[str]:
+    data = json.loads((WEB_MESSAGES_DIR / f"{locale}.json").read_text(encoding="utf-8"))
+    return set(data["organizerType"].keys())
+
+
+@pytest.mark.parametrize("locale", ["zh", "en", "ja"])
+def test_web_messages_organizer_type_keys_match_canonical(locale):
+    assert _load_organizer_type_keys(locale) == set(CANONICAL_STORAGE_TYPES)
+
+
+def test_web_messages_three_languages_have_equal_keys():
+    zh = _load_organizer_type_keys("zh")
+    en = _load_organizer_type_keys("en")
+    ja = _load_organizer_type_keys("ja")
+    assert zh == en == ja
+
+
+@pytest.mark.parametrize("locale", ["zh", "en", "ja"])
+def test_web_messages_exclude_actor_only_values(locale):
+    keys = _load_organizer_type_keys(locale)
+    for actor in ACTOR_ONLY_VALUES:
+        assert actor not in keys
+
+
+# ===========================================================================
+# 3. Migration 095 legacy JSON-text -> scalar normalize (mirrors SQL 2a/2b)
+# ===========================================================================
+
+def _normalize_organizer_type_scalar(value):
+    """Pure-Python mirror of migration 095 section 2 (steps 2a + 2b).
+
+    2a: an unambiguous single-element bracketed array of a legal value is
+        promoted to its bare scalar form (text ops only).
+    2b: any remaining non-null value that is not a legal scalar becomes NULL.
+    """
+    if value is None:
+        return None
+    trimmed = value.strip()
+    # 2a — single-element bracketed array (no comma) of a legal value.
+    if trimmed.startswith("[") and trimmed.endswith("]") and "," not in value:
+        inner = trimmed.strip("[]").strip(" '\"")
+        if inner in CANONICAL_STORAGE_TYPES:
+            return inner
+    # 2b — keep an already-legal scalar, else NULL.
+    return value if value in CANONICAL_STORAGE_TYPES else None
+
+
+def test_normalize_json_text_double_quote_to_scalar():
+    # The only live non-null value (2 rows) at authoring time.
+    assert _normalize_organizer_type_scalar('["commercial_brand"]') == "commercial_brand"
+
+
+def test_normalize_python_repr_single_quote_to_scalar():
+    assert _normalize_organizer_type_scalar("['commercial_brand']") == "commercial_brand"
+
+
+def test_normalize_multi_value_array_becomes_null():
+    # Ambiguous multi-element array -> NULL (manual review), never silently
+    # flattened to a single value.
+    assert _normalize_organizer_type_scalar('["academic","media"]') is None
+
+
+def test_normalize_illegal_legacy_scalar_becomes_null():
+    assert _normalize_organizer_type_scalar("corporate") is None
+
+
+def test_normalize_already_legal_scalar_is_preserved():
+    assert _normalize_organizer_type_scalar("commercial_brand") == "commercial_brand"
+    assert _normalize_organizer_type_scalar("individual") == "individual"
+
+
+def test_normalize_null_stays_null():
+    assert _normalize_organizer_type_scalar(None) is None
+
+
+# ===========================================================================
+# 4. events cardinality CHECK predicate (mirrors the SQL COALESCE semantics)
+# ===========================================================================
+
+def _card(arr):
+    """Mirror SQL COALESCE(cardinality(x), 0): NULL and [] both -> 0."""
+    return len(arr) if isinstance(arr, list) else 0
+
+
+def _cardinality_ok(names, types):
+    return _card(names) == _card(types)
+
+
+@pytest.mark.parametrize(
+    "names,types,expected",
+    [
+        (["a", "b"], ["t1", "t2"], True),   # aligned
+        (["a", "b"], ["t1"], False),        # names longer
+        (["a"], ["t1", "t2"], False),       # types longer
+        ([], [], True),                      # both empty
+        (None, None, True),                  # both null
+        ([], None, True),                    # empty vs null -> both 0
+        (None, [], True),                    # null vs empty -> both 0
+        (["a"], None, False),               # single name, null types
+        (None, ["t1"], False),              # null names, single type
+    ],
+)
+def test_cardinality_predicate_fail_pass_semantics(names, types, expected):
+    assert _cardinality_ok(names, types) is expected
+
+
+# ===========================================================================
+# 5. Migration 095 structural fixture
+# ===========================================================================
+
+def _migration_sql() -> str:
+    return MIGRATION_095.read_text(encoding="utf-8")
+
+
+def _migration_executable_sql() -> str:
+    """Migration text with `--` line comments removed.
+
+    Structural assertions must validate the executable statements, not the
+    explanatory prose (which legitimately mentions GRANT / NOT VALID / <@ ARRAY
+    / events_organizer_type_check while describing what the migration avoids).
+    Migration 095 contains no `--` inside any string literal, so this naive
+    stripper is safe.
+    """
+    out = []
+    for line in _migration_sql().splitlines():
+        idx = line.find("--")
+        if idx != -1:
+            line = line[:idx]
+        out.append(line)
+    return "\n".join(out)
+
+
+def test_migration_file_exists():
+    assert MIGRATION_095.is_file()
+
+
+def test_migration_declares_both_cardinality_checks_validated():
+    sql = _migration_executable_sql()
+    assert "events_co_org_cardinality_check" in sql
+    assert "events_sponsor_cardinality_check" in sql
+    assert "COALESCE(cardinality(co_organizers), 0) = COALESCE(cardinality(co_organizer_types), 0)" in sql
+    assert "COALESCE(cardinality(sponsors), 0) = COALESCE(cardinality(sponsor_types), 0)" in sql
+    # Validated CHECK (fail-closed): must NOT be deferred with NOT VALID.
+    assert "NOT VALID" not in sql.upper()
+
+
+def test_migration_research_sources_uses_scalar_in_not_array_subset():
+    sql = _migration_executable_sql()
+    assert "research_sources_default_organizer_type_check" in sql
+    assert "default_organizer_type IS NULL OR" in sql
+    # Scalar column must not borrow the events text[] "<@ ARRAY[...]" syntax.
+    assert "default_organizer_type <@" not in sql
+    assert "<@ ARRAY" not in sql
+
+
+def test_migration_declares_ten_value_sets_for_scalar_constraints():
+    sql = _migration_executable_sql()
+    # Every canonical value must appear inside a quoted literal, and the
+    # storage-only 'individual' must be present in the new scalar CHECKs.
+    for value in CANONICAL_STORAGE_TYPES:
+        assert f"'{value}'" in sql
+    assert "organizers_organizer_type_check" in sql
+
+
+def test_migration_adds_is_authoritative_and_partial_index():
+    sql = _migration_executable_sql()
+    assert "ADD COLUMN IF NOT EXISTS is_authoritative BOOL NOT NULL DEFAULT false" in sql
+    assert "idx_organizers_is_authoritative" in sql
+    assert "WHERE is_authoritative = true" in sql
+
+
+def test_migration_is_transaction_wrapped():
+    sql = _migration_executable_sql()
+    assert "BEGIN;" in sql
+    assert "COMMIT;" in sql
+    assert sql.index("BEGIN;") < sql.index("COMMIT;")
+
+
+def test_migration_touches_no_permissions_or_views():
+    sql = _migration_executable_sql().upper()
+    # Assert there is no executable GRANT / REVOKE / ALTER VIEW statement
+    # (comment prose is stripped before this check).
+    for token in ("GRANT ", "REVOKE ", "ALTER VIEW", "CREATE VIEW", "CREATE OR REPLACE VIEW"):
+        assert token not in sql
+
+
+def test_migration_does_not_touch_events_organizer_type_column():
+    sql = _migration_executable_sql()
+    # 095 must not redefine the events.organizer_type text[] constraint (086).
+    assert "events_organizer_type_check" not in sql
+
+
+# ===========================================================================
+# 6. OPT-IN read-only DB gate (set TTR_RUN_DB_GATE=1) — no writes
+# ===========================================================================
+
+@pytest.mark.skipif(
+    not os.environ.get("TTR_RUN_DB_GATE"),
+    reason="opt-in read-only DB gate; set TTR_RUN_DB_GATE=1 to run",
+)
+def test_db_gate_live_cardinality_mismatch_reports_fail_closed():
+    import database
+
+    def _card_b(arr):
+        # Independent implementation: treat any falsy (None / []) as 0.
+        return 0 if not arr else len(arr)
+
+    sb = database._get_client()
+    page, size, events = 0, 1000, []
+    while True:
+        lo = page * size
+        batch = (
+            sb.table("events")
+            .select("id,co_organizers,co_organizer_types,sponsors,sponsor_types")
+            .range(lo, lo + size - 1)
+            .execute()
+            .data
+        )
+        if not batch:
+            break
+        events.extend(batch)
+        if len(batch) < size:
+            break
+        page += 1
+
+    def pairs(e):
+        yield e.get("co_organizers"), e.get("co_organizer_types")
+        yield e.get("sponsors"), e.get("sponsor_types")
+
+    mismatch_a = sum(
+        1 for e in events for n, t in pairs(e) if _card(n) != _card(t)
+    )
+    mismatch_b = sum(
+        1 for e in events for n, t in pairs(e) if _card_b(n) != _card_b(t)
+    )
+
+    # Two independent cardinality implementations must agree exactly.
+    assert mismatch_a == mismatch_b
+
+    validated_check_creatable = mismatch_a == 0
+    print(
+        f"[DB GATE] events={len(events)} table-wide co/sponsor mismatch pairs="
+        f"{mismatch_a} -> validated CHECK creatable={validated_check_creatable}"
+    )
+
+    # Fail-closed gate contract: the validated CHECK is creatable IFF there is
+    # zero table-wide mismatch. This assertion holds both pre-gate (mismatch>0
+    # -> not creatable) and post-A.5 (mismatch==0 -> creatable).
+    assert validated_check_creatable == (mismatch_a == 0)

--- a/scraper/tests/test_seed_authoritative_organizers.py
+++ b/scraper/tests/test_seed_authoritative_organizers.py
@@ -1,0 +1,222 @@
+"""Unit tests for ``seed_authoritative_organizers`` (Wave 2 Phase D seed).
+
+Every DB interaction is mocked, so nothing depends on a live database or on
+migration 095's ``organizers.is_authoritative`` column. The dry-run path is
+asserted to never write.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+import seed_authoritative_organizers as seed
+
+
+# --------------------------------------------------------------------------- #
+# Fake Supabase client                                                         #
+# --------------------------------------------------------------------------- #
+class _OrgBuilder:
+    """One-shot query builder for the ``organizers`` table."""
+
+    def __init__(self, client):
+        self.client = client
+        self._cols = None
+        self._eq = {}
+
+    def select(self, cols):
+        self._cols = cols
+        return self
+
+    def eq(self, col, val):
+        self._eq[col] = val
+        return self
+
+    def limit(self, _n):
+        return self
+
+    def execute(self):
+        # Schema probe: is_authoritative is absent pre-migration 095.
+        if self.client.schema_missing and self._cols and "is_authoritative" in self._cols:
+            raise RuntimeError("column organizers.is_authoritative does not exist")
+        canonical = self._eq.get("canonical_name_ja")
+        if canonical is not None:
+            row = self.client.existing.get(canonical)
+            return SimpleNamespace(data=[dict(row)] if row else [])
+        return SimpleNamespace(data=[])
+
+    def upsert(self, payload, on_conflict=None):
+        self.client.upserts.append((payload, on_conflict))
+        return SimpleNamespace(execute=lambda: SimpleNamespace(data=[]))
+
+
+class _FakeClient:
+    def __init__(self, existing=None, schema_missing=True):
+        self.existing = existing or {}
+        self.schema_missing = schema_missing
+        self.upserts: list = []
+
+    def table(self, name):
+        assert name == "organizers", name
+        return _OrgBuilder(self)
+
+
+@pytest.fixture
+def _patch_client(monkeypatch):
+    def _install(client):
+        monkeypatch.setattr(seed, "_get_client", lambda: client)
+    return _install
+
+
+# --------------------------------------------------------------------------- #
+# 1. Pre-flight: alias / canonical collision (pure)                            #
+# --------------------------------------------------------------------------- #
+def test_alias_collision_detected():
+    entries = [
+        {"canonical_name_ja": "A社", "aliases": ["共用"], "organizer_type": "commercial_brand"},
+        {"canonical_name_ja": "B社", "aliases": ["共用"], "organizer_type": "commercial_brand"},
+    ]
+    collisions = seed.check_alias_collisions(entries)
+    assert "共用" in collisions
+    assert collisions["共用"] == ["A社", "B社"]
+
+
+def test_canonical_as_other_alias_is_collision():
+    entries = [
+        {"canonical_name_ja": "有隣堂", "aliases": [], "organizer_type": "commercial_brand"},
+        {"canonical_name_ja": "株式会社有隣堂", "aliases": ["有隣堂"], "organizer_type": "commercial_brand"},
+    ]
+    collisions = seed.check_alias_collisions(entries)
+    assert "有隣堂" in collisions
+
+
+def test_no_collision_in_core_seed():
+    # The shipped core list must itself be collision-free.
+    assert seed.check_alias_collisions(seed.SEED_DATA) == {}
+
+
+# --------------------------------------------------------------------------- #
+# 2. Seed type validity (pure)                                                 #
+# --------------------------------------------------------------------------- #
+def test_core_seed_types_all_canonical():
+    assert seed.validate_seed_types(seed.SEED_DATA) == []
+
+
+def test_illegal_seed_type_flagged():
+    bad = seed.validate_seed_types(
+        [{"canonical_name_ja": "X", "organizer_type": "traveler"}]
+    )
+    assert bad == ["X"]
+
+
+# --------------------------------------------------------------------------- #
+# 3. evaluate_entry: existing type conflict → rejected                         #
+# --------------------------------------------------------------------------- #
+def test_existing_type_conflict_rejects(_patch_client):
+    client = _FakeClient(
+        existing={"紀伊國屋書店": {
+            "id": "org-1", "canonical_name_ja": "紀伊國屋書店",
+            "aliases": ["紀伊国屋書店"], "organizer_type": "cultural_institution",
+        }},
+        schema_missing=False,
+    )
+    _patch_client(client)
+    entry = next(e for e in seed.SEED_DATA if e["canonical_name_ja"] == "紀伊國屋書店")
+    plan = seed.evaluate_entry(client, entry, set())
+    assert plan["type_conflict"] == "cultural_institution"
+    assert plan["rejected"] is True
+    assert plan["action"] == "update"
+
+
+def test_matching_existing_type_not_conflict(_patch_client):
+    client = _FakeClient(
+        existing={"誠品書店": {
+            "id": "org-2", "canonical_name_ja": "誠品書店",
+            "aliases": [], "organizer_type": "commercial_brand",
+        }},
+        schema_missing=False,
+    )
+    _patch_client(client)
+    entry = next(e for e in seed.SEED_DATA if e["canonical_name_ja"] == "誠品書店")
+    plan = seed.evaluate_entry(client, entry, set())
+    assert plan["type_conflict"] is None
+    assert plan["rejected"] is False
+
+
+def test_insert_action_when_not_present(_patch_client):
+    client = _FakeClient(existing={}, schema_missing=False)
+    _patch_client(client)
+    entry = seed.SEED_DATA[0]
+    plan = seed.evaluate_entry(client, entry, set())
+    assert plan["action"] == "insert"
+    assert plan["before"]["exists"] is False
+
+
+# --------------------------------------------------------------------------- #
+# 4. Schema compatibility: missing is_authoritative flagged, never crashes     #
+# --------------------------------------------------------------------------- #
+def test_schema_missing_flagged_not_ready():
+    client = _FakeClient(schema_missing=True)
+    assert seed.check_schema_ready(client) is False
+
+
+def test_schema_ready_when_present():
+    client = _FakeClient(schema_missing=False)
+    assert seed.check_schema_ready(client) is True
+
+
+def test_dry_run_graceful_when_schema_missing(_patch_client, capsys):
+    client = _FakeClient(existing={}, schema_missing=True)
+    _patch_client(client)
+    result = seed.run(dry_run=True)
+    assert result["schema_ready"] is False
+    # Full plan still produced for every core entry despite the missing column.
+    assert len(result["plans"]) == len(seed.SEED_DATA)
+    out = capsys.readouterr().out
+    assert "需先 apply migration 095" in out
+
+
+# --------------------------------------------------------------------------- #
+# 5. Dry-run must never write                                                  #
+# --------------------------------------------------------------------------- #
+def test_dry_run_writes_nothing(_patch_client):
+    client = _FakeClient(existing={}, schema_missing=False)
+    _patch_client(client)
+    seed.run(dry_run=True)
+    assert client.upserts == []
+
+
+def test_dry_run_all_core_seedable_when_no_conflict(_patch_client):
+    client = _FakeClient(existing={}, schema_missing=False)
+    _patch_client(client)
+    result = seed.run(dry_run=True)
+    assert result["seedable"] == len(seed.SEED_DATA)
+    assert result["rejected"] == 0
+    assert client.upserts == []
+
+
+# --------------------------------------------------------------------------- #
+# 6. Manifest candidate discovery (human review only)                         #
+# --------------------------------------------------------------------------- #
+def test_load_manifest_candidates_filters_a1(tmp_path):
+    import json
+    manifest = {
+        "entities": [
+            {"canonical": "髙島屋", "aliases": ["高島屋"], "cohorts": ["A1"],
+             "keyword_signals": {"dept": ["髙島屋"]}, "event_count": 5,
+             "distinct_meaningful_types": ["commercial_brand"]},
+            {"canonical": "ある市民の会", "aliases": [], "cohorts": ["A2"],
+             "keyword_signals": {}, "event_count": 2,
+             "distinct_meaningful_types": ["civic_group"]},
+            # Already in the core seed list → excluded.
+            {"canonical": "紀伊國屋書店", "aliases": [], "cohorts": ["A1"],
+             "keyword_signals": {"bookstore": ["紀伊國屋書店"]}, "event_count": 3,
+             "distinct_meaningful_types": ["commercial_brand"]},
+        ]
+    }
+    p = tmp_path / "audit.json"
+    p.write_text(json.dumps(manifest, ensure_ascii=False), encoding="utf-8")
+    cands = seed.load_manifest_candidates(str(p))
+    names = {c["canonical"] for c in cands}
+    assert "髙島屋" in names          # A1 dept candidate surfaced
+    assert "ある市民の会" not in names  # A2 non-retail excluded
+    assert "紀伊國屋書店" not in names  # already seeded → excluded

--- a/supabase/migrations/095_organizer_authority.sql
+++ b/supabase/migrations/095_organizer_authority.sql
@@ -1,0 +1,182 @@
+-- ============================================================
+-- 095: organizer_authority
+-- Wave 2 Phase B0a (storage enum reconciliation) + Phase B
+-- (organizers authority columns + events co/sponsor cardinality guards),
+-- merged into one transaction-wrapped, rollback-safe migration.
+--
+-- ⛔ APPLY PREREQUISITE (READ BEFORE RUNNING) — fail-closed by design:
+--   The two events cardinality CHECK constraints in section 3 are ordinary
+--   VALIDATED constraints (NOT "NOT VALID"). At authoring time the live DB
+--   has 70 parallel-array mismatches (66 distinct events; co=63 / sponsor=7;
+--   17 active / 53 inactive) across the WHOLE table. Applying this migration
+--   before Phase A.5 remediation has driven that count to 0 will make the
+--   `ALTER TABLE events ADD CONSTRAINT ...` step ERROR and abort the entire
+--   transaction, leaving nothing half-applied. This is intentional:
+--       gate 2A  = Phase A.5 apply  -> table-wide co/sponsor mismatch = 0
+--       gate 2B  = THIS migration
+--   Do NOT paste this into the SQL Editor until the gate-2A read-back shows a
+--   table-wide (active + inactive) mismatch of 0.
+--
+-- SCOPE / NON-SCOPE:
+--   * Touches: research_sources (CHECK swap), organizers (normalize + new
+--     column + CHECK + partial index), events (two cardinality CHECKs).
+--   * Does NOT touch events.organizer_type (already the 10-value text[] set
+--     established by migration 086).
+--   * Contains NO GRANT / REVOKE / ALTER VIEW: no new table and no permission
+--     change, so no Data-API GRANT block (October-30 policy) is required.
+--   * Does NOT modify the already-applied historical migrations 039 / 058 /
+--     086; it only re-shapes the constraints they created.
+--
+-- CANONICAL STORAGE VOCABULARY (10 values) — authoritative source is the live
+-- events_organizer_type_check (migration 086):
+--     government, semi_official, cultural_institution, academic,
+--     commercial_brand, independent_venue, civic_group, media,
+--     individual, unknown
+--   (The annotator LLM vocabulary deliberately stays at 9 values and never
+--    emits 'individual'; 'individual' is a storage/registry-only value.)
+--
+-- ROLLBACK (manual, only if ever needed after a successful apply):
+--     BEGIN;
+--     ALTER TABLE events DROP CONSTRAINT IF EXISTS events_sponsor_cardinality_check;
+--     ALTER TABLE events DROP CONSTRAINT IF EXISTS events_co_org_cardinality_check;
+--     DROP INDEX IF EXISTS idx_organizers_is_authoritative;
+--     ALTER TABLE organizers DROP CONSTRAINT IF EXISTS organizers_organizer_type_check;
+--     ALTER TABLE organizers DROP COLUMN IF EXISTS is_authoritative;
+--     ALTER TABLE research_sources DROP CONSTRAINT IF EXISTS research_sources_default_organizer_type_check;
+--     ALTER TABLE research_sources ADD CONSTRAINT research_sources_default_organizer_type_check
+--       CHECK (default_organizer_type IS NULL OR default_organizer_type IN (
+--         'government','semi_official','cultural_institution','academic',
+--         'commercial_brand','independent_venue','civic_group','media','unknown'));
+--     COMMIT;
+--   NOTE: the legacy organizers.organizer_type JSON-text form
+--   ('["commercial_brand"]') is NOT auto-restored on rollback (the scalar
+--   form is intentionally lossy); re-seed from the audit manifest if required.
+--
+-- Admin must run in Supabase Dashboard -> SQL Editor.
+-- ============================================================
+
+BEGIN;
+
+-- ------------------------------------------------------------
+-- 1. research_sources.default_organizer_type — B0a scalar CHECK swap.
+--    Migration 039 seeded a 9-value CHECK. Extend it to the canonical 10
+--    (adds 'individual'). This is a SCALAR text column, so keep the
+--    "IS NULL OR ... IN (...)" form; do NOT copy the events "<@ ARRAY[...]"
+--    array-column syntax.
+--
+--    Live DISTINCT non-null values at authoring time (31 rows, every value
+--    already inside the old 9-value set, so the 10-value superset rejects
+--    nothing):
+--        academic, commercial_brand, cultural_institution, government,
+--        independent_venue, media, semi_official
+-- ------------------------------------------------------------
+ALTER TABLE research_sources
+  DROP CONSTRAINT IF EXISTS research_sources_default_organizer_type_check;
+
+ALTER TABLE research_sources
+  ADD CONSTRAINT research_sources_default_organizer_type_check
+  CHECK (
+    default_organizer_type IS NULL OR
+    default_organizer_type IN (
+      'government','semi_official','cultural_institution','academic',
+      'commercial_brand','independent_venue','civic_group','media',
+      'individual','unknown'
+    )
+  );
+
+-- ------------------------------------------------------------
+-- 2. organizers — B: normalize legacy JSON-text organizer_type to scalar,
+--    add is_authoritative, add the canonical 10-value scalar CHECK, and a
+--    partial index for authoritative lookups.
+--
+--    Live DISTINCT non-null organizer_type at authoring time (2 of 204 rows):
+--        '["commercial_brand"]'   -> normalizes to scalar 'commercial_brand'
+--    No multi-value or illegal values are present. The two-step normalize
+--    below is defensive and lossless for legal single values:
+--      2a. promote UNAMBIGUOUS single-element bracketed arrays of a legal
+--          value to their scalar form using PURE TEXT ops -> it never casts
+--          to jsonb, so it cannot throw on malformed data;
+--      2b. NULL out any remaining non-null value that is not already a legal
+--          scalar (multi-value arrays / illegal / unparseable) and leave it
+--          for manual review. No legal information is silently dropped,
+--          because step 2a has already rescued every unambiguous legal value.
+-- ------------------------------------------------------------
+
+-- 2a. Unambiguous single-element legal array -> scalar.
+--     btrim(btrim(btrim(x), '[]'), ' ''"') strips outer spaces, then the
+--     surrounding brackets, then any spaces / single-quotes / double-quotes,
+--     yielding the bare value. The single-element guard rejects any value
+--     containing a comma (i.e. multi-element arrays).
+UPDATE organizers AS o
+SET organizer_type = btrim(btrim(btrim(o.organizer_type), '[]'), ' ''"')
+WHERE o.organizer_type IS NOT NULL
+  AND btrim(o.organizer_type) LIKE '[%]'
+  AND position(',' IN o.organizer_type) = 0
+  AND btrim(btrim(btrim(o.organizer_type), '[]'), ' ''"') IN (
+    'government','semi_official','cultural_institution','academic',
+    'commercial_brand','independent_venue','civic_group','media',
+    'individual','unknown'
+  );
+
+-- 2b. Anything still non-null and not a legal scalar -> NULL (manual review).
+--     Expected to affect 0 rows given the authoring-time data.
+UPDATE organizers
+SET organizer_type = NULL
+WHERE organizer_type IS NOT NULL
+  AND organizer_type NOT IN (
+    'government','semi_official','cultural_institution','academic',
+    'commercial_brand','independent_venue','civic_group','media',
+    'individual','unknown'
+  );
+
+ALTER TABLE organizers
+  ADD COLUMN IF NOT EXISTS is_authoritative BOOL NOT NULL DEFAULT false;
+
+ALTER TABLE organizers
+  DROP CONSTRAINT IF EXISTS organizers_organizer_type_check;
+
+ALTER TABLE organizers
+  ADD CONSTRAINT organizers_organizer_type_check
+  CHECK (
+    organizer_type IS NULL OR
+    organizer_type IN (
+      'government','semi_official','cultural_institution','academic',
+      'commercial_brand','independent_venue','civic_group','media',
+      'individual','unknown'
+    )
+  );
+
+CREATE INDEX IF NOT EXISTS idx_organizers_is_authoritative
+  ON organizers(is_authoritative) WHERE is_authoritative = true;
+
+COMMENT ON COLUMN organizers.is_authoritative IS
+  'When true, the organizer registry resolver treats this row as the canonical entity type (unless a field_corrections lock exists). LLM output must never flip this flag.';
+
+-- ------------------------------------------------------------
+-- 3. events — B: durable co/sponsor parallel-array cardinality guards.
+--    ⚠️ VALIDATED constraints (no NOT VALID): PostgreSQL scans the whole
+--    table when adding them, so they FAIL CLOSED if ANY table-wide mismatch
+--    remains (70 pairs at authoring time). Apply only after gate 2A = 0.
+--    COALESCE collapses both NULL and empty-array to 0, so "no entries" on
+--    either side is treated as equal (0 = 0).
+--    DROP IF EXISTS makes re-runs idempotent.
+-- ------------------------------------------------------------
+ALTER TABLE events
+  DROP CONSTRAINT IF EXISTS events_co_org_cardinality_check;
+
+ALTER TABLE events
+  ADD CONSTRAINT events_co_org_cardinality_check
+  CHECK (
+    COALESCE(cardinality(co_organizers), 0) = COALESCE(cardinality(co_organizer_types), 0)
+  );
+
+ALTER TABLE events
+  DROP CONSTRAINT IF EXISTS events_sponsor_cardinality_check;
+
+ALTER TABLE events
+  ADD CONSTRAINT events_sponsor_cardinality_check
+  CHECK (
+    COALESCE(cardinality(sponsors), 0) = COALESCE(cardinality(sponsor_types), 0)
+  );
+
+COMMIT;


### PR DESCRIPTION
## Wave 2 — Organizer Type Authority (code-only cycle)

建立 organizer authority registry，讓已驗證的主辦單位 entity 一次分類、永久生效，取代每日 GPT 對 `organizer_type` 的重複推斷（修 entity drift，如「台湾文化センター」四型並存、書店被誤判文化機構）。

### Commits (6)
1. audit manifest tool `audit_organizers.py`（唯讀）
2. A.5 `_oneoff_repair_organizer_type_arrays.py`（parallel-array cardinality repair, dry-run）
3. migration `095_organizer_authority.sql`：research_sources/organizers scalar enum 10 值 + organizers `is_authoritative` + events co/sponsor cardinality CHECK + boundary tests
4. `organizer_registry.py`（graceful + fail-closed alias）+ `database.py::_populate_entity_fks`（移除 `.limit(1)` 任選）
5. `annotator.py` 整合 `_apply_organizer_registry`（primary scalar→array 四案 + co/sponsor cardinality parity + `_NON_TEXT_FC_FIELDS` 對稱補全）
6. `seed_authoritative_organizers.py` + `backfill_organizer_authority.py`（dry-run；backfill 委派 annotator 四案）

### ⚠️ Code-only — 不可 merge 後遺忘；production apply 需依序 gate
本 PR 只含程式碼。migration 095 **未 apply**、seed/backfill 皆 **dry-run**。merge 後依嚴格順序 apply：
1. **Gate 2A** — A.5 `--apply` → 全表 co/sponsor mismatch = 0（70 pairs / 66 events，含 53 inactive）
2. **Gate 2B** — apply migration 095（需 2A=0；否則 validated cardinality CHECK fail-closed）
3. **Gate 2C** — seed `--apply` + backfill `--apply`（需 095）→ production post-check

### Safety
- **Graceful degradation**：095 apply 前 `organizers.is_authoritative` 不存在 → registry 空 → `_apply_organizer_registry` byte-for-byte no-op → 每日 CI annotation 行為不變。
- **無 `web/` 變更**。
- Full regression **467 passed, 1 skipped**（已 rebase 到最新 origin/main，含 taiwan_expo_japan）。
- Tester 統一驗證 **PASS 7/7**。

🤖 Generated with Copilot