### PR TITLE
ci(deps): add manual dependency verification workflow

### DIFF
--- a/.github/workflows/deps-verify.yml
+++ b/.github/workflows/deps-verify.yml
@@ -1,0 +1,105 @@
+# Temporary dependency-verification tool, NOT a per-PR dependency CI gate: manual dispatch plus a single branch only.
+# Rationale: the local device blocks the public npm registry, so lockfiles can only be verified on a CI runner.
+# E2E is intentionally out of scope here — web-darkmode-smoke.yml already covers the Playwright surface.
+name: deps-verify
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref or SHA to verify (default: PR #205 head)'
+        required: true
+        default: 'ec8a26c42300ecdc51f369174cdb084fdf697850'
+  push:
+    branches: [chore/deps-security]
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout target ref
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: ${{ github.event.inputs.ref || github.sha }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: 10.33.3
+
+      # No dependency cache on purpose: a restored store would mask the thing under test,
+      # namely that every locked version is still fetchable from the public registry.
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 20
+
+      - name: Create .env.local for CI
+        working-directory: web
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          SITE_URL: ${{ secrets.NEXT_PUBLIC_SITE_URL }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          {
+            echo "NEXT_PUBLIC_SUPABASE_URL=${SUPABASE_URL}"
+            echo "NEXT_PUBLIC_SUPABASE_ANON_KEY=${SUPABASE_ANON_KEY}"
+            echo "NEXT_PUBLIC_SITE_URL=${SITE_URL}"
+            echo "SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY}"
+            echo "OPENAI_API_KEY=${OPENAI_API_KEY}"
+            echo "NEXT_PUBLIC_SENTRY_DSN=${SENTRY_DSN}"
+          } >> .env.local
+
+      - name: install --frozen-lockfile --ignore-scripts (blocking)
+        working-directory: web
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: install --frozen-lockfile (blocking)
+        working-directory: web
+        run: pnpm install --frozen-lockfile
+
+      # Evidence steps: must print even when a vulnerable instance is still resolved,
+      # so continue-on-error keeps the real exit status visible without stopping the job.
+      - name: list advisory packages (evidence, non-blocking)
+        working-directory: web
+        continue-on-error: true
+        run: pnpm list js-yaml nanoid postcss brace-expansion sharp --depth Infinity
+
+      - name: why per advisory package (evidence, non-blocking)
+        working-directory: web
+        continue-on-error: true
+        run: |
+          for pkg in js-yaml nanoid postcss brace-expansion sharp; do
+            echo "::group::pnpm why ${pkg}"
+            pnpm why "${pkg}" || true
+            echo "::endgroup::"
+          done
+
+      - name: tsc --noEmit (blocking)
+        working-directory: web
+        run: pnpm exec tsc --noEmit
+
+      - name: lint (blocking)
+        working-directory: web
+        run: pnpm lint
+
+      - name: node tests (blocking)
+        working-directory: web
+        run: pnpm exec tsx --test tests/*.test.ts
+
+      - name: build (blocking)
+        working-directory: web
+        run: pnpm build
+
+      # Reports vulnerabilities without failing the job; severity triage stays a human decision.
+      - name: audit (report-only)
+        working-directory: web
+        continue-on-error: true
+        run: pnpm audit --audit-level=moderate

--- a/.github/workflows/deps-verify.yml
+++ b/.github/workflows/deps-verify.yml
@@ -92,9 +92,29 @@ jobs:
         working-directory: web
         run: pnpm exec tsc --noEmit
 
-      - name: lint (blocking)
+      # Report-only by design: main already carries baseline lint debt, and the approved plan
+      # requires separating that baseline from changed-hunk regressions. Blocking here would
+      # hide the build/audit signals this workflow exists to collect. The printed counts are
+      # the baseline that a dependency bump (e.g. eslint-config-next) must be compared against.
+      - name: lint (report-only, baseline-comparable)
         working-directory: web
-        run: pnpm lint
+        continue-on-error: true
+        env:
+          TARGET_REF: ${{ github.event.inputs.ref || github.sha }}
+        run: |
+          set +e
+          pnpm lint 2>&1 | tee /tmp/lint.txt
+          code=${PIPESTATUS[0]}
+          summary="$(grep -oE '[0-9]+ problems \([0-9]+ errors, [0-9]+ warnings\)' /tmp/lint.txt | tail -1)"
+          echo "LINT_EXIT=${code}"
+          echo "LINT_SUMMARY=${summary:-none}"
+          {
+            echo "### lint (report-only)"
+            echo ""
+            echo "- ref: \`${TARGET_REF}\`"
+            echo "- exit: \`${code}\`"
+            echo "- summary: \`${summary:-none}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: node tests (blocking)
         working-directory: web

--- a/.github/workflows/deps-verify.yml
+++ b/.github/workflows/deps-verify.yml
@@ -65,6 +65,12 @@ jobs:
         working-directory: web
         run: pnpm install --frozen-lockfile
 
+      # tsc and lint import lib/specs/*.json, which are gitignored build-time artifacts
+      # normally produced by prebuild — so they must be generated before any type check.
+      - name: Generate specs snapshot (blocking)
+        working-directory: web
+        run: pnpm run build-specs-snapshot
+
       # Evidence steps: must print even when a vulnerable instance is still resolved,
       # so continue-on-error keeps the real exit status visible without stopping the job.
       - name: list advisory packages (evidence, non-blocking)

--- a/docs/specs/active/workstream-tracking/tasks.md
+++ b/docs/specs/active/workstream-tracking/tasks.md
@@ -295,6 +295,26 @@ git --no-pager cherry origin/main <branch>   # '-' 前綴 = 內容已在上游
 下一步需先恢復對目標 registry 的存取（移除本機 proxy 設定或改用可達公開 npm 的環境），
 再重跑 Phase 1B 完整驗證。
 
+#### G4 Phase 1 後續：registry 存取的長期解
+
+短期已加入 `.github/workflows/deps-verify.yml`（手動 `workflow_dispatch` 與 `chore/deps-security`
+push 觸發）作為繞道，讓驗證改在可連公開 npm 的 runner 上執行。**該 workflow 尚未取得任何執行結果**，
+9 筆 alert identity 仍全數 `OPEN`。以下兩項為尚未著手的長期解：
+
+- [ ] **B（長期）**：請 1ES feed 擁有者 ingest 缺少的版本。後端為
+      `ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/`，
+      metadata 回 200 但特定版本 tarball 404，因為 packument 內根本沒有該版本
+      （例：nanoid `3.3.16` present → 303；`3.3.17`、`3.3.18` absent → 404）。
+      缺版含 `@types/node 26.2.0`，該版本已存在於 `origin/main` 現有 lockfile，
+      因此連 main 都無法本機 clean install。
+      **這是反覆性問題**：每次 Dependabot bump 都會再撞一次缺版，
+      需要建立常態的 ingest 流程或自動補版機制，一次性補件無法收斂
+- [ ] **C（長期）**：請裝置政策擁有者評估放行 `registry.npmjs.org`。
+      攔截發生在 TLS 層而非設定層——DNS 正常、TCP 443 可連，
+      但 Client Hello 之後連線即被切斷（`Recv failure: Socket is not connected`），
+      裝置裝有 Microsoft Defender。因此**修改 npmrc 無效**，
+      必須由裝置政策端處置
+
 ### G5: Worktree 註冊路徑漂移
 
 - [x] 保存 10 個 worktree 的完整 registered path、physical path 與 path class 證據

--- a/docs/specs/active/workstream-tracking/tasks.md
+++ b/docs/specs/active/workstream-tracking/tasks.md
@@ -249,6 +249,52 @@ git --no-pager cherry origin/main <branch>   # '-' 前綴 = 內容已在上游
 - [ ] Dependabot 回報 9 個依賴漏洞（8 high、1 moderate），與本專案工作無關但需處理。
       **性質上不屬於工作線盤點**，僅暫置於此；建議另立資安維護歸屬
 
+#### G4 依賴維護：固定驗收集合（2026-08-10 重查，9 筆皆 `open`）
+
+以 alert identity 作終局判定，不以 alert 總數代替。
+
+| Alert | GHSA | package | severity | first patched |
+|---|---|---|---|---|
+| #45 | GHSA-f88m-g3jw-g9cj | `sharp` | high | 0.35.0 |
+| #50 | GHSA-3jxr-9vmj-r5cp | `brace-expansion` | high | 1.1.16 |
+| #51 | GHSA-r28c-9q8g-f849 | `postcss` | high | 8.5.18 |
+| #53 | GHSA-mh99-v99m-4gvg | `brace-expansion` | high | 5.0.8 |
+| #54 | GHSA-rgw5-rvv9-x895 | `brace-expansion` | high | 5.0.9 |
+| #60 | GHSA-fxqj-rqcc-2cmp | `postcss` | medium | 8.5.23 |
+| #61 | GHSA-5p4m-2wfm-xmqj | `js-yaml` | high | 4.3.1 |
+| #62 | GHSA-5p4m-2wfm-xmqj | `js-yaml` | high | 3.15.1 |
+| #63 | GHSA-2v37-7h3g-55p8 | `nanoid` | high | 3.3.17 |
+
+全 9 筆 manifest 皆為 `web/pnpm-lock.yaml`。
+
+#### G4 Phase 1：PR #205 驗證於本機環境受阻
+
+- [ ] PR #205（`chore(deps)`，minor-and-patch group，15 updates）尚未驗證，**未 merge**
+
+已確認的事實：
+
+- exact `baseRefOid` `ebf3daae`、`headRefOid` `ec8a26c4`，changed files 僅
+  `web/package.json`、`web/pnpm-lock.yaml`，符合 scope 限制
+- dependency-file drift gate `ebf3daae..origin/main` 輸出為空，main 對這兩個檔案零漂移，
+  不需 `@dependabot rebase`
+
+阻擋原因為**本機 registry 不可達**，不是 PR 本身缺陷，也不構成 `BLOCKED_BY_UPSTREAM`：
+
+- 本機 npm registry 被 `~/.npmrc`、`/usr/local/etc/npmrc`、`/opt/homebrew/etc/npmrc`
+  設為 `https://packagefeedproxy.microsoft.io/npm/`；repo 未追蹤任何 `.npmrc`，
+  CI 與 Vercel 實際使用的目標 registry 是公開 npm
+- 該 proxy 對較新版本回 404（`electron-to-chromium@1.5.402`、`node-releases@2.0.53`、
+  `nanoid@3.3.18`、`postcss@8.5.26`），較舊版本（如 `electron-to-chromium@1.5.350`）則正常
+- **控制組證明屬環境問題**：`origin/main` 自己的 lockfile 走同一 proxy 亦
+  `ERR_PNPM_FETCH_404` 失敗，與 PR #205 無關
+- `registry.npmjs.org` 在 sandbox 內外皆不可達（`Recv failure: Socket is not connected`）
+
+因此 9 筆 identity 現況一律為 `OPEN`，無任何一筆可判為 `FIXED` 或 `BLOCKED_BY_UPSTREAM`。
+未使用 `dismissed`、未 ignore audit、未降低 audit level。
+
+下一步需先恢復對目標 registry 的存取（移除本機 proxy 設定或改用可達公開 npm 的環境），
+再重跑 Phase 1B 完整驗證。
+
 ### G5: Worktree 註冊路徑漂移
 
 - [x] 保存 10 個 worktree 的完整 registered path、physical path 與 path class 證據


### PR DESCRIPTION
## Why

The local dev machine cannot resolve the npm lockfile, so dependency work (PR #205 and the 9 open Dependabot alerts) cannot be verified locally. Two independent causes were confirmed:

1. **Public npm blocked at the TLS layer** — DNS resolves and TCP 443 connects, but the TLS handshake is terminated (`Recv failure: Socket is not connected`). Changing `.npmrc` does not help; the block is not in configuration.
2. **The corporate proxy is missing specific versions** — `packagefeedproxy.microsoft.io` serves packument metadata (200) but 404s on tarballs whose versions it never ingested (e.g. `nanoid` 3.3.16 → 303, but 3.3.17/3.3.18 → 404).

A control run proved this is environmental, not a defect in any PR: `pnpm install --frozen-lockfile` fails on **`main`'s own lockfile** locally.

## What

Adds `.github/workflows/deps-verify.yml`, a CI-side verification harness so lockfiles can be validated on a runner with public npm access.

- **Not a per-PR gate.** Triggers are `workflow_dispatch` (with a `ref` input) and `push` limited to `chore/deps-security`.
- `permissions: contents: read`; all three actions pinned to commit SHAs.
- Secrets are written only to `web/.env.local`, never echoed. CI logs verified free of secret material.
- No `cache: pnpm` **on purpose** — a restored store would mask the exact thing under test, namely whether every locked version is still fetchable.
- `install` ×2, specs snapshot, `tsc`, node tests and `build` are blocking; `list` / `why` / `lint` / `audit` are report-only so their evidence is always collected.
- `lint` is report-only because `main` carries pre-existing debt; it emits `LINT_EXIT` / `LINT_SUMMARY` so a dependency bump stays numerically comparable against the baseline.
- E2E is out of scope here — `web-darkmode-smoke.yml` already covers that surface.

Also records the two long-term follow-ups in the workstream tracking spec (both left unchecked): asking the 1ES feed to ingest missing versions, and asking the device-policy owner to evaluate allowing `registry.npmjs.org`.

## Verification

Run [31337614925](https://github.com/TuiTuiKoan/Tokyo_Taiwan_Radar/actions/runs/31337614925) — **success**, 15 steps, 0 skipped.

- `install --frozen-lockfile --ignore-scripts`: `resolved 756, reused 0, downloaded 756` with **zero** `ERR_PNPM_FETCH_404`. `reused 0` confirms a real cold fetch rather than a cache hit.
- `tsc --noEmit` clean; node tests **164 pass / 0 fail**; `build` succeeded in 40s.

Baseline captured for later comparison against PR #205:

| Signal | Value |
|---|---|
| lint | `217 problems (164 errors, 53 warnings)` |
| audit | 13 vulnerability instances across 12 advisories |

Advisory reconciliation: the 12 advisories are the 9 tracked alerts (#45, #50, #51, #53, #54, #60, #61, #62, #63) plus 3 that Dependabot auto-dismissed on 2026-08-08 (#58, #59, #64). No alert was dismissed manually.

## Scope

`web/package.json` and `web/pnpm-lock.yaml` are byte-identical to `main` — this PR changes no dependencies. Only the workflow and the tracking spec are touched.

**This does not verify PR #205.** The run above validated `main`'s baseline lockfile. Verifying #205 requires `workflow_dispatch`, which GitHub only exposes once the workflow lives on the default branch — that is the reason for this PR.

## Follow-ups (not in this PR)

- `@supabase/supabase-js` warns that Node ≤20 support will be dropped; the repo has no `engines` or `.nvmrc`, so CI and Vercel have no single source of truth for the Node version.
- The `LINT_SUMMARY` scalar cannot detect a net-zero change where an upgrade removes N old findings and introduces N new ones.

🔍 - Generated by Copilot