### PR TITLE
chore(deps): resolve remaining brace-expansion and js-yaml advisories

### DIFF
--- a/.github/workflows/deps-lockfile-sync.yml
+++ b/.github/workflows/deps-lockfile-sync.yml
@@ -1,0 +1,121 @@
+# Companion to deps-verify.yml. The local dev device cannot reach the public npm registry,
+# so an override added to web/package.json can only be resolved into a lockfile on a runner.
+# This is the only workflow in the repo that requests contents: write, and main has no branch
+# protection, so the two hard guards below (branch allowlist, change-scope allowlist) are the
+# sole line of defence and must fail closed.
+name: deps-lockfile-sync
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to sync (must match chore/deps-*)'
+        required: true
+        default: 'chore/deps-security'
+  push:
+    branches: ['chore/deps-**']
+    paths: ['web/package.json']
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    # Belt and braces against a self-trigger loop: GITHUB_TOKEN pushes never re-trigger
+    # workflows, and the paths filter above already excludes this job's lockfile-only commit.
+    if: github.actor != 'github-actions[bot]'
+    permissions:
+      contents: write
+
+    steps:
+      # Deliberately ahead of checkout: the branch name is validated before it reaches
+      # actions/checkout or git push, so neither ever sees an unvetted ref.
+      - name: Resolve and validate target branch
+        id: target
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_BRANCH: ${{ github.event.inputs.branch }}
+          PUSH_BRANCH: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            target="${DISPATCH_BRANCH}"
+          else
+            target="${PUSH_BRANCH}"
+          fi
+          case "${target}" in
+            ''|main|master|HEAD|*..*)
+              echo "::error::refusing protected, empty or traversal branch: '${target}'"
+              exit 1
+              ;;
+          esac
+          if ! printf '%s' "${target}" | grep -Eq '^chore/deps-[A-Za-z0-9._/-]+$'; then
+            echo "::error::branch must match chore/deps-*: '${target}'"
+            exit 1
+          fi
+          echo "branch=${target}" >> "$GITHUB_OUTPUT"
+          echo "validated target branch: ${target}"
+
+      - name: Checkout target branch
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: ${{ steps.target.outputs.branch }}
+          persist-credentials: true
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: 10.33.3
+
+      # No dependency cache on purpose, same reason as deps-verify: a restored store would
+      # mask whether every newly resolved version is actually fetchable from the registry.
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 20
+
+      - name: Resolve lockfile against updated manifest
+        working-directory: web
+        run: pnpm install --no-frozen-lockfile
+
+      # Runs from the repo root so --porcelain paths are repo-relative. -uall expands
+      # untracked directories, so a stray new file cannot hide inside a collapsed entry.
+      - name: Enforce lockfile-only change scope
+        id: scope
+        run: |
+          set -euo pipefail
+          paths="$(git status --porcelain=v1 -uall | cut -c4- | sort -u)"
+          if [ -z "${paths}" ]; then
+            echo "lockfile already in sync; nothing to commit"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "${paths}" != "web/pnpm-lock.yaml" ]; then
+            echo "::error::install touched paths other than web/pnpm-lock.yaml"
+            git status --porcelain=v1 -uall
+            exit 1
+          fi
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          git --no-pager diff --stat -- web/pnpm-lock.yaml
+
+      - name: Commit and push lockfile
+        if: steps.scope.outputs.changed == 'true'
+        env:
+          TARGET_BRANCH: ${{ steps.target.outputs.branch }}
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add -- web/pnpm-lock.yaml
+          staged="$(git diff --cached --name-only)"
+          if [ "${staged}" != "web/pnpm-lock.yaml" ]; then
+            echo "::error::staged set is not exactly web/pnpm-lock.yaml"
+            printf '%s\n' "${staged}"
+            exit 1
+          fi
+          git commit \
+            -m 'chore(deps): sync pnpm lockfile' \
+            -m 'Resolved on CI by deps-lockfile-sync after a web/package.json override change, because the local device cannot reach the public npm registry.'
+          git push origin "HEAD:refs/heads/${TARGET_BRANCH}"
+          echo "pushed $(git rev-parse HEAD) to ${TARGET_BRANCH}"

--- a/.github/workflows/deps-lockfile-sync.yml
+++ b/.github/workflows/deps-lockfile-sync.yml
@@ -3,6 +3,9 @@
 # This is the only workflow in the repo that requests contents: write, and main has no branch
 # protection, so the two hard guards below (branch allowlist, change-scope allowlist) are the
 # sole line of defence and must fail closed.
+# Manual dispatch only: the earlier push trigger existed so the workflow could run before it
+# reached the default branch. That is done, and an automatic write-permission job on every
+# chore/deps-** push is attack surface with no remaining purpose.
 name: deps-lockfile-sync
 
 on:
@@ -12,9 +15,6 @@ on:
         description: 'Branch to sync (must match chore/deps-*)'
         required: true
         default: 'chore/deps-security'
-  push:
-    branches: ['chore/deps-**']
-    paths: ['web/package.json']
 
 permissions:
   contents: read
@@ -22,8 +22,8 @@ permissions:
 jobs:
   sync:
     runs-on: ubuntu-latest
-    # Belt and braces against a self-trigger loop: GITHUB_TOKEN pushes never re-trigger
-    # workflows, and the paths filter above already excludes this job's lockfile-only commit.
+    # Kept after the push trigger was dropped: a workflow_dispatch can still be fired over the
+    # REST API by another workflow's GITHUB_TOKEN, and this blocks such a bot-initiated chain.
     if: github.actor != 'github-actions[bot]'
     permissions:
       contents: write
@@ -34,23 +34,23 @@ jobs:
       - name: Resolve and validate target branch
         id: target
         env:
-          EVENT_NAME: ${{ github.event_name }}
           DISPATCH_BRANCH: ${{ github.event.inputs.branch }}
-          PUSH_BRANCH: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
-            target="${DISPATCH_BRANCH}"
-          else
-            target="${PUSH_BRANCH}"
-          fi
+          target="${DISPATCH_BRANCH}"
           case "${target}" in
             ''|main|master|HEAD|*..*)
               echo "::error::refusing protected, empty or traversal branch: '${target}'"
               exit 1
               ;;
+            *[$'\n'$'\r']*)
+              echo "::error::control character in branch name"
+              exit 1
+              ;;
           esac
-          if ! printf '%s' "${target}" | grep -Eq '^chore/deps-[A-Za-z0-9._/-]+$'; then
+          # Bash =~ tests the whole string; grep matched line by line, so an embedded newline
+          # could pass the allowlist and then write a second branch= line into GITHUB_OUTPUT.
+          if [[ ! "${target}" =~ ^chore/deps-[A-Za-z0-9._/-]+$ ]]; then
             echo "::error::branch must match chore/deps-*: '${target}'"
             exit 1
           fi
@@ -75,9 +75,13 @@ jobs:
         with:
           node-version: 20
 
+      # --ignore-scripts is required, not cosmetic: pnpm only blocks dependency build scripts
+      # by default, so the root project's own preinstall/postinstall hooks in web/package.json
+      # would still run here with contents: write and a credential-bearing .git/config.
+      # Lockfile resolution does not depend on lifecycle scripts, so output is unchanged.
       - name: Resolve lockfile against updated manifest
         working-directory: web
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --no-frozen-lockfile --ignore-scripts
 
       # Runs from the repo root so --porcelain paths are repo-relative. -uall expands
       # untracked directories, so a stray new file cannot hide inside a collapsed entry.

--- a/web/package.json
+++ b/web/package.json
@@ -52,8 +52,9 @@
       "postcss": ">=8.5.10",
       "dompurify": "^3.4.11",
       "@babel/core": "^7.29.6",
-      "js-yaml@3": "^3.15.0",
-      "js-yaml@4": "^4.2.0",
+      "brace-expansion@1": "^1.1.18",
+      "js-yaml@3": "^3.15.1",
+      "js-yaml@4": "^4.3.1",
       "@opentelemetry/core": "^2.8.0"
     }
   }

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -8,8 +8,9 @@ overrides:
   postcss: '>=8.5.10'
   dompurify: ^3.4.11
   '@babel/core': ^7.29.6
-  js-yaml@3: ^3.15.0
-  js-yaml@4: ^4.2.0
+  brace-expansion@1: ^1.1.18
+  js-yaml@3: ^3.15.1
+  js-yaml@4: ^4.3.1
   '@opentelemetry/core': ^2.8.0
 
 importers:
@@ -1966,8 +1967,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  brace-expansion@1.1.14:
-    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
   brace-expansion@5.0.9:
     resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
@@ -2957,12 +2958,12 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -4374,7 +4375,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -5777,7 +5778,7 @@ snapshots:
 
   baseline-browser-mapping@2.11.13: {}
 
-  brace-expansion@1.1.14:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -6691,7 +6692,7 @@ snapshots:
 
   gray-matter@4.0.3:
     dependencies:
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -6965,12 +6966,12 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -7496,7 +7497,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.14
+      brace-expansion: 1.1.18
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
## Why

Three Dependabot alerts survived PR #205 because they sit on transitive chains that a direct bump cannot reach:

| Alert | Package | Chain | Needs |
|---|---|---|---|
| #50 | `brace-expansion` | `eslint > minimatch` | `>=1.1.16` |
| #61 | `js-yaml` | `eslint > @eslint/eslintrc` | `>=4.3.1` |
| #62 | `js-yaml` | `gray-matter` | `>=3.15.1` |

## What

Adds one `pnpm.overrides` entry and bumps two existing ones. The other four overrides (`postcss`, `dompurify`, `@babel/core`, `@opentelemetry/core`) are untouched.

```
brace-expansion@1  (new)     ^1.1.18
js-yaml@3          ^3.15.0 → ^3.15.1
js-yaml@4          ^4.2.0  → ^4.3.1
```

Also adds `.github/workflows/deps-lockfile-sync.yml`. The local dev device cannot reach the public npm registry — public npm is blocked at the TLS layer, and the corporate proxy 404s on versions it never ingested — so an override edit can only be resolved into a lockfile on a runner. The lockfile in this PR was produced by that workflow, not by hand.

## Verification

Run [31405082967](https://github.com/TuiTuiKoan/Tokyo_Taiwan_Radar/actions/runs/31405082967) against the synced lockfile:

- `pnpm audit --audit-level=moderate` → **`No known vulnerabilities found`** (13 → 5 after #205 → 0 here)
- `install --frozen-lockfile` passes, so the generated lockfile matches the manifest
- lint `218 problems (164 errors, 54 warnings)` — byte-identical to the pre-change baseline, no regression
- `tsc`, node tests (164 pass / 0 fail) and `build` all pass

Resolved versions: `brace-expansion@1.1.18`, `js-yaml@3.15.1`, `js-yaml@4.3.1`. No vulnerable instance of either package remains in the tree.

## On the write-permission workflow

`deps-lockfile-sync.yml` is the only workflow here that requests `contents: write`, and `main` has no branch protection, so its guards were reviewed as an attack surface. Two gaps were found and closed before this PR:

- **`--ignore-scripts` was missing.** pnpm 10 blocks *dependency* build scripts by default but not the root project's own `preinstall`, so a `chore/deps-*` branch carrying a malicious hook could have run code against a credential-bearing runner.
- **The branch allowlist used `grep`, which matches line by line.** `chore/deps-x\nbranch=main` passed the check and could then write a second `branch=` line into `GITHUB_OUTPUT`. Now uses a whole-string bash regex plus an explicit control-character rejection.

The `push` trigger was also dropped. It existed only so the workflow could run before reaching the default branch; that is no longer needed, and an automatic write-permission job on every `chore/deps-**` push is attack surface with no remaining purpose. Dispatch is now manual only, the branch allowlist is `chore/deps-*`, and the job may only ever commit `web/pnpm-lock.yaml`.

Guard behaviour was verified by extracting the shell with a YAML parser and running it against 13 inputs under both bash 3.2 and 5.1: `main`, `master`, `HEAD`, empty, `refs/heads/main`, path traversal, shell metacharacters and the newline/CR injections are all rejected with zero `GITHUB_OUTPUT` writes, while valid `chore/deps-*` names still pass.

## Expected after merge

Dependabot rescans the default branch, so #50, #61 and #62 should flip to `fixed`, taking the open count to zero.

🔒 - Generated by Copilot